### PR TITLE
Correct invest Icon name

### DIFF
--- a/invest-applet/data/org.mate.applets.InvestApplet.mate-panel-applet.in.in
+++ b/invest-applet/data/org.mate.applets.InvestApplet.mate-panel-applet.in.in
@@ -7,7 +7,7 @@ _Description=Factory for creating the invest applet.
 [InvestApplet]
 _Name=Invest
 _Description=Track your invested money.
-Icon=invest-applet
+Icon=mate-invest-applet
 BonoboId=OAFIID:Invest_Applet_Factory
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets


### PR DESCRIPTION
The icons are all prefixed with mate but this was never changed for the invest applet.
