### PR TITLE
Replace old gconf with gsettings schema

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -38,7 +38,6 @@ mateweather/mateweather-dialog.c
 mateweather/mateweather-pref.c
 mateweather/main.c
 [type: gettext/ini]mateweather/org.mate.applets.MateWeatherApplet.mate-panel-applet.in.in
-invest-applet/data/Invest_Applet.xml
 invest-applet/data/org.mate.applets.InvestApplet.mate-panel-applet.in.in
 invest-applet/data/org.mate.panel.applet.InvestAppletFactory.service.in
 [type: gettext/glade]invest-applet/data/financialchart.ui


### PR DESCRIPTION
mini-commander was removed and mixer applet moved to mate-media so I removed them.

Make check now fails with the following but I don't know why. if you know do let me know and I'll add it to this PR.

<pre>$ LANG="en_US.UTF-8" make check
Making check in po
make[1]: Entering directory `/home/sander/repos/mate-applets/po'
INTLTOOL_EXTRACT="/usr/bin/intltool-extract" XGETTEXT="/usr/bin/xgettext" srcdir=. /usr/bin/intltool-update --gettext-package mate-applets --pot

junk after document element at line 2, column 0, byte 45 at /usr/lib64/perl5/vendor_perl/5.16.3/x86_64-linux/XML/Parser.pm line 187.
/usr/bin/xgettext: error while opening "../invest-applet/data/Invest_Applet.xml.h" for reading: No such file or directory
ERROR: xgettext failed to generate PO template file. Please consult
       error message above if there is any.
make[1]: *** [mate-applets.pot] Error 1
make[1]: Leaving directory `/home/sander/repos/mate-applets/po'
make: *** [check-recursive] Error 1</pre>
