### PR TITLE
Require pygobject 3 now that it was ported to gi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -713,7 +713,7 @@ mate-applets-$VERSION configure summary:
         - drivemount               always
         - geyes                    always
         - mateweather              $build_libmateweather_applets
-        - invest-applet            $BUILD_INVEST_APPLET
+        - invest-applet            $HAVE_PYGOBJECT
         - modemlights              $BUILD_MODEM_LIGHTS
         - multiload                $build_gtop_applets
         - stickynotes              $enable_stickynotes


### PR DESCRIPTION
Commit 540e2e460c8155a22b10c1712eec71c9bf25aea9 ported to
gobject introspection but this never reflected in configure.ac.

edit: timer applet was not ported and was disabled.
