### PR TITLE
battstat applet: save panel space

### DIFF
--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -854,9 +854,9 @@ update_percent_label( ProgressData *battstat, BatteryStatus *info )
     new_label = g_strdup_printf ("%d%%", info->percent);
   else if (info->present && battstat->showtext == APPLET_SHOW_TIME)
   {
-    /* Fully charged or unknown (-1) time remaining displays -:-- */
+    /* Fully charged or unknown (-1) time remaining display none */
     if ((info->on_ac_power && info->percent == 100) || info->minutes < 0)
-      new_label = g_strdup ("-:--");
+      new_label = g_strdup ("");
     else
     {
       int time;


### PR DESCRIPTION
using an empty label instead of -:-- when fully charged or unknown
![screenshot diff](https://f.cloud.github.com/assets/663076/1895498/aa714aae-7b35-11e3-8cfb-23e0354f8427.png)
