### PR TITLE
fix building of the accessx-status applet

### DIFF
--- a/accessx-status/Makefile.am
+++ b/accessx-status/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = docs pixmaps
 AM_CPPFLAGS = \
 	$(MATE_APPLETS4_CFLAGS) \
 	$(MATEDESKTOP_CFLAGS) \
+	$(GIO_CFLAGS) \
 	-DACCESSX_PIXMAPS_DIR=\""$(datadir)/pixmaps/mate-accessx-status-applet"\" \
 	-DACCESSX_MENU_UI_DIR=\""$(uidir)"\"
 


### PR DESCRIPTION
I have been unable to build mate-applets since recent commits that added gio(desktopappinfo) to one of the applets. The relevant bit of my build log is:

```
Merging translations into org.mate.applets.AccessxStatusApplet.mate-panel-applet.
applet.c:29:33: fatal error: gio/gdesktopappinfo.h: No such file or directory
 #include <gio/gdesktopappinfo.h>
                                 ^
compilation terminated.
```

More importantly, this PR fixes the issue. 
