### PR TITLE
GTK3: fix panel orientation from weather applet

### DIFF
--- a/mateweather/mateweather-applet.c
+++ b/mateweather/mateweather-applet.c
@@ -42,8 +42,8 @@
 #define MAX_CONSECUTIVE_FAULTS (3)
 
 #if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
-#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
+#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
+#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
 #endif
 
 static void about_cb (GtkAction      *action,


### PR DESCRIPTION
without this commit the temperature displays under the icon at horizontal panels and conversely at vertical panels