### PR TITLE
charpick, geyes: restore icons on buttons in prefs dialogs

### DIFF
--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -850,8 +850,9 @@ charpicker_applet_fill (MatePanelApplet *applet)
   }
   g_object_unref (action_group);
 
+  register_stock_for_edit ();
   populate_menu (curr_data);
-  
+
   return TRUE;
 }
 

--- a/charpick/charpick.h
+++ b/charpick/charpick.h
@@ -42,6 +42,7 @@ struct _charpick_button_cb_data {
 
 
 void start_callback_update(void);
+void register_stock_for_edit (void);
 
 void build_table              (charpick_data     *curr_data);
 void add_to_popup_menu (charpick_data *curr_data);

--- a/charpick/properties.c
+++ b/charpick/properties.c
@@ -13,10 +13,33 @@
 #include <atk/atkrelation.h>
 #include <gtk/gtk.h>
 
+#define CHARPICK_STOCK_EDIT "charpick-stock-edit"
+
 #if GTK_CHECK_VERSION (3, 0, 0)
 #define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
 #define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
 #endif
+
+void
+register_stock_for_edit (void)
+{
+  static gboolean registered = FALSE;
+  if (!registered)
+  {
+    GtkIconFactory *factory;
+    GtkIconSet     *icons;
+
+    static const GtkStockItem edit_item [] = {
+           { CHARPICK_STOCK_EDIT, N_("_Edit"), 0, 0, GETTEXT_PACKAGE },
+    };
+    icons = gtk_icon_factory_lookup_default (GTK_STOCK_PREFERENCES);
+    factory = gtk_icon_factory_new ();
+    gtk_icon_factory_add (factory, CHARPICK_STOCK_EDIT, icons);
+    gtk_icon_factory_add_default (factory);
+    gtk_stock_add_static (edit_item, 1);
+    registered = TRUE;
+  }
+}
 
 #if 0
 static void
@@ -75,8 +98,8 @@ add_edit_dialog_create (charpick_data *curr_data, gchar *string, gchar *title)
 
 	dialog = gtk_dialog_new_with_buttons (_(title), GTK_WINDOW (curr_data->propwindow),
 							    GTK_DIALOG_DESTROY_WITH_PARENT,
-							    _("_Cancel"), GTK_RESPONSE_CANCEL,
-							    _("_OK"), GTK_RESPONSE_OK,
+							    GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
+							    GTK_STOCK_OK, GTK_RESPONSE_OK,
 							    NULL);
 
 	gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (curr_data->propwindow));
@@ -447,14 +470,14 @@ static void default_chars_frame_create(charpick_data *curr_data)
   
   vbox2 = gtk_vbox_new (FALSE, 6);
   gtk_box_pack_start (GTK_BOX (hbox), vbox2, FALSE, FALSE, 0);
-  button = gtk_button_new_with_mnemonic (_("_Add"));
+  button = gtk_button_new_from_stock (GTK_STOCK_ADD);
   gtk_box_pack_start (GTK_BOX (vbox2), button, FALSE, FALSE, 0);
   g_signal_connect (G_OBJECT (button), "clicked",
   			     G_CALLBACK (add_palette), curr_data);
   set_access_namedesc (button, _("Add button"),
 				         _("Click to add a new palette"));
  
-  button = gtk_button_new_with_mnemonic (_("_Edit"));
+  button = gtk_button_new_from_stock (CHARPICK_STOCK_EDIT);
   gtk_box_pack_start (GTK_BOX (vbox2), button, FALSE, FALSE, 0);
   g_signal_connect (G_OBJECT (button), "clicked",
   			     G_CALLBACK (edit_palette), curr_data);
@@ -462,7 +485,7 @@ static void default_chars_frame_create(charpick_data *curr_data)
   set_access_namedesc (button, _("Edit button"),
 				         _("Click to edit the selected palette"));
   
-  button = gtk_button_new_with_mnemonic (_("_Delete"));
+  button = gtk_button_new_from_stock (GTK_STOCK_DELETE);
   gtk_box_pack_start (GTK_BOX (vbox2), button, FALSE, FALSE, 0);
   g_signal_connect (G_OBJECT (button), "clicked",
   			     G_CALLBACK (delete_palette), curr_data);
@@ -522,8 +545,8 @@ show_preferences_dialog (GtkAction     *action,
   curr_data->propwindow = gtk_dialog_new_with_buttons (_("Character Palette Preferences"), 
   					    NULL,
 					    GTK_DIALOG_DESTROY_WITH_PARENT,
-					    _("_Close"), GTK_RESPONSE_CLOSE,
-					    _("_Help"), GTK_RESPONSE_HELP,
+					    GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
+					    GTK_STOCK_HELP, GTK_RESPONSE_HELP,
 					    NULL);
   gtk_window_set_screen (GTK_WINDOW (curr_data->propwindow),
 			 gtk_widget_get_screen (curr_data->applet));

--- a/geyes/themes.c
+++ b/geyes/themes.c
@@ -285,8 +285,8 @@ properties_cb (GtkAction  *action,
 
         pbox = gtk_dialog_new_with_buttons (_("Geyes Preferences"), NULL,
         				     GTK_DIALOG_DESTROY_WITH_PARENT,
-					     _("_Close"), GTK_RESPONSE_CLOSE,
-					     _("_Help"), GTK_RESPONSE_HELP,
+					     GTK_STOCK_CLOSE, GTK_RESPONSE_CLOSE,
+					     GTK_STOCK_HELP, GTK_RESPONSE_HELP,
 					     NULL);
 
 	gtk_window_set_screen (GTK_WINDOW (pbox),


### PR DESCRIPTION
Removing something that users see and interact with only to fix some "deprecations" wasn't right. Let's get the icons back.