### PR TITLE
Bugfixes and theme support

### DIFF
--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -319,6 +319,20 @@ populate_menu (charpick_data *curr_data)
 		list = g_list_next (list);
 	}
 	build_table(curr_data);
+	
+	/*Set up custom theme and transparency support*/
+#if GTK_CHECK_VERSION (3, 0, 0) 
+	GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/* Set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+#endif	
 }
 
 static void

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -432,17 +432,17 @@ cpufreq_applet_size_request (GtkWidget *widget, GtkRequisition *requisition)
 	if (applet->orient == MATE_PANEL_APPLET_ORIENT_LEFT ||
 	    applet->orient == MATE_PANEL_APPLET_ORIENT_RIGHT)
 		return;
-
+	/*Specify numerical values so labels in gtk3 don't get zero width  */
 	if (applet->show_freq) {
-		labels_width += cpufreq_applet_get_max_label_width (applet) + 2;
+		labels_width += 50;
 	}
 
 	if (applet->show_perc) {
-		labels_width += cpufreq_applet_get_max_perc_width (applet);
+		labels_width += 50;
 	}
 
 	if (applet->show_unit) {
-		labels_width += cpufreq_applet_get_max_unit_width (applet);
+		labels_width += 20;
 	}
 
 	if (applet->show_icon) {
@@ -521,7 +521,7 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
 
         *x = menu_xpos;
         *y = menu_ypos;
-        *push_in = TRUE;
+        if (push_in) *push_in = FALSE;  /*fix botttom panel menu rendering in gtk3*/
 }
 
 static void

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -16,7 +16,7 @@
  *  License along with this library; if not, write to the Free
  *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
  *
- * Authors : Carlos García Campos <carlosgc@gnome.org>
+ * Authors : Carlos GarcÃ­a Campos <carlosgc@gnome.org>
  */
 
 #ifdef HAVE_CONFIG_H
@@ -543,7 +543,20 @@ cpufreq_applet_menu_popup (CPUFreqApplet *applet,
 
         if (!menu)
                 return;
-
+                
+        /*Set up theme and transparency support*/
+#if GTK_CHECK_VERSION (3, 0, 0) 
+        GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
+        /* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+        GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+        GdkVisual *visual = gdk_screen_get_rgba_visual(screen);
+        gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+        /* Set menu and it's toplevel window to follow panel theme */
+        GtkStyleContext *context;
+        context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+        gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+        gtk_style_context_add_class(context,"mate-panel-menu-bar");
+#endif
         gtk_menu_popup (GTK_MENU (menu), NULL, NULL,
                         cpufreq_applet_popup_position_menu,
                         (gpointer) applet,

--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -989,4 +989,18 @@ drive_button_ensure_popup (DriveButton *self)
 	g_free (label);
 	gtk_container_add (GTK_CONTAINER (self->popup_menu), item);
     }
+       /*Set up custom theme and transparency support */
+#if GTK_CHECK_VERSION (3, 0, 0)  
+	GtkWidget *toplevel = gtk_widget_get_toplevel (self->popup_menu);
+	/* Fix any failures of compiz/other wm's to communicate with gtk for transparency */
+	GdkScreen *screen2 = gtk_widget_get_screen(GTK_WIDGET(toplevel));
+	GdkVisual *visual = gdk_screen_get_rgba_visual(screen2);
+	gtk_widget_set_visual(GTK_WIDGET(toplevel), visual); 
+	/*set menu and it's toplevel window to follow panel theme */
+	GtkStyleContext *context;
+	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
+	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
+	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
+	gtk_style_context_add_class(context,"mate-panel-menu-bar");
+#endif 
 }


### PR DESCRIPTION
Drivemount: support custom gtk3 panel themes, robust support for transparent themes
Charpick: support custom gtk3 panel themes, robust support for transparent themes
Cpufreq: support custom gtk3 panel themes, robust support for transparent themes
Cpufreq: fix gtk3 rendering issues with 0px wide labels and bottom panel rendering. Someone should check to ensure label width fix does not cause gtk2 issues but the direct numerical width specification should work there too. This one committed last in case issues arise in gtk2 so it can be split out