### PR TITLE
drivemount: Don't remove background

### DIFF
--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -1000,7 +1000,6 @@ drive_button_ensure_popup (DriveButton *self)
 	/*set menu and it's toplevel window to follow panel theme */
 	GtkStyleContext *context;
 	context = gtk_widget_get_style_context (GTK_WIDGET(toplevel));
-	gtk_style_context_remove_class (context,GTK_STYLE_CLASS_BACKGROUND);
 	gtk_style_context_add_class(context,"gnome-panel-menu-bar");
 	gtk_style_context_add_class(context,"mate-panel-menu-bar");
 #endif


### PR DESCRIPTION
This fixes the invisible text for GTK+ 3 themes which don't support mate-panel explicitly. Themes could still overwrite the background if they want in the usual way.