### PR TITLE
GTK 3.20 cpufreq: fix themes clipping units label

### DIFF
--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -334,12 +334,7 @@ cpufreq_applet_get_max_label_width (CPUFreqApplet *applet)
 		label = gtk_label_new (freq_text);
 #if GTK_CHECK_VERSION (3, 0, 0)
 		gtk_widget_get_preferred_width (applet->label, &label_width, NULL);
-
-#if GTK_CHECK_VERSION (3, 19, 0)
-		width = MAX (width, label_width)-2;
-#else
-		width = MAX (width, label_width);
-#endif
+		width = MAX (width, label_width); 
 #endif
 #if !GTK_CHECK_VERSION (3, 0, 0)
 		gtk_widget_size_request (label, &req);


### PR DESCRIPTION
Stop BlackMATE, possibly other themes from cutting off the end of the units label and get rid of an #if block for GTK 3.19 at the same time.  GTK 3.19 seemed to pad the end of this label a bit, not so with released GTK 3.20.