### PR TITLE
drop dependency to libmate-deskop

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,6 @@ GLIB_REQUIRED=2.36.0
 GIO_REQUIRED=2.15.3
 LIBPANEL4_REQUIRED=1.7.0
 LIBGTOP_REQUIRED=2.11.92
-LIBMATE_DESKTOP_REQUIRED=1.9.0
 LIBNOTIFY_REQUIRED=0.7.0
 UPOWER_REQUIRED=0.9.4
 DBUS_REQUIRED=1.1.2
@@ -135,11 +134,6 @@ dnl -- check for libmatepanelapplet4 (required) --------------------------------
 PKG_CHECK_MODULES(MATE_APPLETS4, libmatepanelapplet-4.0 >= $LIBPANEL4_REQUIRED)
 AC_SUBST(MATE_APPLETS4_CFLAGS)
 AC_SUBST(MATE_APPLETS4_LIBS)
-
-dnl -- check for mate-desktop (required) -------------------------------------
-PKG_CHECK_MODULES(MATEDESKTOP, mate-desktop-2.0 >= $LIBMATE_DESKTOP_REQUIRED)
-AC_SUBST(MATEDESKTOP_CFLAGS)
-AC_SUBST(MATEDESKTOP_LIBS)
 
 dnl -- check for libgtop (optional) -------------------------------------------
 build_gtop_applets=false

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -97,7 +97,8 @@ typedef struct
 	gboolean show_icon, short_unit;
 	gboolean show_quality_icon;
 #if GTK_CHECK_VERSION (3, 0, 0)
-	GdkRGBA in_color, out_color;
+	GdkRGBA         in_color;
+	GdkRGBA         out_color;
 #else
 	GdkColor in_color, out_color;
 #endif
@@ -1137,16 +1138,23 @@ da_expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
 	return FALSE;
 }
 
-static void
 #if GTK_CHECK_VERSION (3, 0, 0)
-incolor_changed_cb (GtkColorChooser *cb, gpointer data)
+static void
+incolor_changed_cb (GtkColorChooser *button, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
-	gchar *color;
-	GdkRGBA clr;
+	GdkRGBA color;
+	gchar *string;
 
-	gtk_color_chooser_get_rgba (cb, &clr);
+	gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (button), &color);
+	applet->in_color = color;
+
+	string = gdk_rgba_to_string (&color);
+	g_settings_set_string (applet->gsettings, "in-color", string);
+	g_free (string);
+}
 #else
+static void
 incolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
@@ -1154,24 +1162,31 @@ incolor_changed_cb (GtkColorButton *cb, gpointer data)
 	GdkColor clr;
 
 	gtk_color_button_get_color (cb, &clr);
-#endif
 	applet->in_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
 	g_settings_set_string (applet->gsettings, "in-color", color);
 	g_free (color);
 }
+#endif
 
-static void
 #if GTK_CHECK_VERSION (3, 0, 0)
-outcolor_changed_cb (GtkColorChooser *cb, gpointer data)
+static void
+outcolor_changed_cb (GtkColorChooser *button, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
-	gchar *color;
-	GdkRGBA clr;
+	GdkRGBA color;
+	gchar *string;
 
-	gtk_color_chooser_get_rgba (cb, &clr);
+	gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (button), &color);
+	applet->out_color = color;
+
+	string = gdk_rgba_to_string (&color);
+	g_settings_set_string (applet->gsettings, "out-color", string);
+	g_free (string);
+}
 #else
+static void
 outcolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
@@ -1179,13 +1194,13 @@ outcolor_changed_cb (GtkColorButton *cb, gpointer data)
 	GdkColor clr;
 
 	gtk_color_button_get_color (cb, &clr);
-#endif
 	applet->out_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
 	g_settings_set_string (applet->gsettings, "out-color", color);
 	g_free (color);
 }
+#endif
 
 /* Handle info dialog response event
  */

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -30,7 +30,6 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include <libmate-desktop/mate-colorbutton.h>
 
 #include "backend.h"
 
@@ -1125,13 +1124,13 @@ da_expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
 }
 
 static void
-incolor_changed_cb (MateColorButton *cb, gpointer data)
+incolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
 	gchar *color;
 	GdkColor clr;
 
-	mate_color_button_get_color (cb, &clr);
+	gtk_color_button_get_color (cb, &clr);
 	applet->in_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
@@ -1140,13 +1139,13 @@ incolor_changed_cb (MateColorButton *cb, gpointer data)
 }
 
 static void
-outcolor_changed_cb (MateColorButton *cb, gpointer data)
+outcolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
 	gchar *color;
 	GdkColor clr;
 
-	mate_color_button_get_color (cb, &clr);
+	gtk_color_button_get_color (cb, &clr);
 	applet->out_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
@@ -1227,11 +1226,11 @@ showinfo_cb(GtkAction *action, gpointer data)
 	incolor_label = gtk_label_new_with_mnemonic(_("_In graph color"));
 	outcolor_label = gtk_label_new_with_mnemonic(_("_Out graph color"));
 
-	incolor_sel =  mate_color_button_new ();
-	outcolor_sel = mate_color_button_new ();
+	incolor_sel = gtk_color_button_new ();
+	outcolor_sel = gtk_color_button_new ();
 
-	mate_color_button_set_color (MATE_COLOR_BUTTON (incolor_sel),  &applet->in_color);
-	mate_color_button_set_color (MATE_COLOR_BUTTON (outcolor_sel),  &applet->out_color);
+	gtk_color_button_set_color (GTK_COLOR_BUTTON (incolor_sel),  &applet->in_color);
+	gtk_color_button_set_color (GTK_COLOR_BUTTON (outcolor_sel),  &applet->out_color);
 
 	gtk_label_set_mnemonic_widget(GTK_LABEL(incolor_label), incolor_sel);
 	gtk_label_set_mnemonic_widget(GTK_LABEL(outcolor_label), outcolor_sel);

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -96,7 +96,11 @@ typedef struct
 	gboolean change_icon, auto_change_device;
 	gboolean show_icon, short_unit;
 	gboolean show_quality_icon;
+#if GTK_CHECK_VERSION (3, 0, 0)
+	GdkRGBA in_color, out_color;
+#else
 	GdkColor in_color, out_color;
+#endif
 	int width;
 
 	GtkWidget *inbytes_text, *outbytes_text;
@@ -498,6 +502,15 @@ redraw_graph(MateNetspeedApplet *applet, cairo_t *cr)
 	cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
 	cairo_set_line_join (cr, CAIRO_LINE_JOIN_ROUND);
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gdk_cairo_set_source_rgba (cr, &applet->in_color);
+	for (i = offset; i < GRAPH_VALUES; i++) {
+		cairo_line_to (cr, in_points[i].x, in_points[i].y);
+	}
+	cairo_stroke (cr);
+
+	gdk_cairo_set_source_rgba (cr, &applet->out_color);
+#else
 	gdk_cairo_set_source_color (cr, &applet->in_color);
 	for (i = offset; i < GRAPH_VALUES; i++) {
 		cairo_line_to (cr, in_points[i].x, in_points[i].y);
@@ -505,6 +518,7 @@ redraw_graph(MateNetspeedApplet *applet, cairo_t *cr)
 	cairo_stroke (cr);
 
 	gdk_cairo_set_source_color (cr, &applet->out_color);
+#endif
 	for (i = offset; i < GRAPH_VALUES; i++) {
 		cairo_line_to (cr, out_points[i].x, out_points[i].y);
 	}
@@ -1124,6 +1138,15 @@ da_expose_event(GtkWidget *widget, GdkEventExpose *event, gpointer data)
 }
 
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+incolor_changed_cb (GtkColorChooser *cb, gpointer data)
+{
+	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
+	gchar *color;
+	GdkRGBA clr;
+
+	gtk_color_chooser_get_rgba (cb, &clr);
+#else
 incolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
@@ -1131,6 +1154,7 @@ incolor_changed_cb (GtkColorButton *cb, gpointer data)
 	GdkColor clr;
 
 	gtk_color_button_get_color (cb, &clr);
+#endif
 	applet->in_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
@@ -1139,6 +1163,15 @@ incolor_changed_cb (GtkColorButton *cb, gpointer data)
 }
 
 static void
+#if GTK_CHECK_VERSION (3, 0, 0)
+outcolor_changed_cb (GtkColorChooser *cb, gpointer data)
+{
+	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
+	gchar *color;
+	GdkRGBA clr;
+
+	gtk_color_chooser_get_rgba (cb, &clr);
+#else
 outcolor_changed_cb (GtkColorButton *cb, gpointer data)
 {
 	MateNetspeedApplet *applet = (MateNetspeedApplet*)data;
@@ -1146,6 +1179,7 @@ outcolor_changed_cb (GtkColorButton *cb, gpointer data)
 	GdkColor clr;
 
 	gtk_color_button_get_color (cb, &clr);
+#endif
 	applet->out_color = clr;
 
 	color = g_strdup_printf ("#%04x%04x%04x", clr.red, clr.green, clr.blue);
@@ -1229,8 +1263,13 @@ showinfo_cb(GtkAction *action, gpointer data)
 	incolor_sel = gtk_color_button_new ();
 	outcolor_sel = gtk_color_button_new ();
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (incolor_sel),  &applet->in_color);
+	gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (outcolor_sel),  &applet->out_color);
+#else
 	gtk_color_button_set_color (GTK_COLOR_BUTTON (incolor_sel),  &applet->in_color);
 	gtk_color_button_set_color (GTK_COLOR_BUTTON (outcolor_sel),  &applet->out_color);
+#endif
 
 	gtk_label_set_mnemonic_widget(GTK_LABEL(incolor_label), incolor_sel);
 	gtk_label_set_mnemonic_widget(GTK_LABEL(outcolor_label), outcolor_sel);
@@ -1692,13 +1731,21 @@ mate_netspeed_applet_factory(MatePanelApplet *applet_widget, const gchar *iid, g
 	tmp = g_settings_get_string (applet->gsettings, "in-color");
 	if (tmp)
 	{
-		gdk_color_parse(tmp, &applet->in_color);
+#if GTK_CHECK_VERSION (3, 0, 0)
+		gdk_rgba_parse (&applet->in_color, tmp);
+#else
+		gdk_color_parse (tmp, &applet->in_color);
+#endif
 		g_free(tmp);
 	}
 	tmp = g_settings_get_string (applet->gsettings, "out-color");
 	if (tmp)
 	{
+#if GTK_CHECK_VERSION (3, 0, 0)
+		gdk_rgba_parse (&applet->out_color, tmp);
+#else
 		gdk_color_parse(tmp, &applet->out_color);
+#endif
 		g_free(tmp);
 	}
 


### PR DESCRIPTION
Using GtkColorButton or GtkColorChooser makes it possible to get rid of deps to libmate-desktop.
MateColorButton was an implementation from Stefano to make my life easier for themes with using a own mate-color-chooser.
But using this lib for an app which set only the line color for a graph does not make any sense.
Here using gtk stuff is sufficient.