### PR TITLE
Stop GTK warnings from trash and inhibit applets

### DIFF
--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -394,9 +394,7 @@ cpufreq_applet_get_preferred_width (GtkWidget *widget, gint *minimum_width, gint
 		gint icon_width;
 
 		gtk_widget_get_preferred_width (applet->icon, &icon_width, NULL);
-		width = gtk_orientable_get_orientation (GTK_ORIENTABLE (applet->box)) == GTK_ORIENTATION_HORIZONTAL ?
-			labels_width + icon_width + 2 :
-			MAX (labels_width, icon_width + 2);
+		width = (labels_width + icon_width + 2);
 	} else {
 		width = labels_width;
 	}

--- a/trashapplet/src/trashapplet.c
+++ b/trashapplet/src/trashapplet.c
@@ -166,6 +166,9 @@ trash_applet_size_allocate (GtkWidget    *widget,
 {
   TrashApplet *applet = TRASH_APPLET (widget);
 
+  GTK_WIDGET_CLASS (trash_applet_parent_class)
+    ->size_allocate (widget, allocation);
+
   switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (applet)))
   {
     case MATE_PANEL_APPLET_ORIENT_LEFT:
@@ -179,8 +182,6 @@ trash_applet_size_allocate (GtkWidget    *widget,
       break;
   }
 
-  GTK_WIDGET_CLASS (trash_applet_parent_class)
-    ->size_allocate (widget, allocation);
 }
 
 static void


### PR DESCRIPTION
Fixes a size allocation warning from the trash and GTK_ORIENTABLE warning from cpufreq-applet