### PR TITLE
drivemount: fix runtime warnings with GTK+ 3.20/22

### DIFF
--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -71,13 +71,25 @@ drive_button_class_init (DriveButtonClass *class)
     GtkCssProvider *provider;
 
     provider = gtk_css_provider_new ();
+
+#if GTK_CHECK_VERSION (3, 20, 0)
     gtk_css_provider_load_from_data (provider,
-                                     "DriveButton {\n"
+                                     "#drive-button {\n"
+                                     " border-width: 0px;\n"
+                                     " padding: 0px;\n"
+                                     " margin: 0px;\n"
+                                     "}",
+                                     -1, NULL);
+#else
+    gtk_css_provider_load_from_data (provider,
+                                     "#drive-button {\n"
                                      " border-width: 0px;\n"
                                      " -GtkWidget-focus-line-width: 0px;\n"
                                      " -GtkWidget-focus-padding: 0px;\n"
                                      "}",
                                      -1, NULL);
+#endif
+
     gtk_style_context_add_provider_for_screen (gdk_screen_get_default(),
                                     GTK_STYLE_PROVIDER (provider),
                                     GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -99,6 +111,8 @@ drive_button_init (DriveButton *self)
     self->update_tag = 0;
 
     self->popup_menu = NULL;
+
+    gtk_widget_set_name (GTK_WIDGET (self), "drive-button");
 }
 
 GtkWidget *


### PR DESCRIPTION
Now I don't know if I do it right, because this time these CSS settings are in class init function, and in fact DriveButton is inherited from GtkButton. So maybe the right thing is to set a class name, not a widget name. But it seems to work anyway, and ```gtk_widget_class_set_css_name``` is only available for GTK+ >= 3.20, while I need to make it work for older versions too. Feel free to make any corrections. :slightly_smiling_face: 