### PR TITLE
Mateweather: suncalc_timeout_cb randomly gets called multiple times (#231)

### DIFF
--- a/mateweather/mateweather-applet.c
+++ b/mateweather/mateweather-applet.c
@@ -502,14 +502,6 @@ update_finish (WeatherInfo *info, gpointer data)
     }
 }
 
-gint suncalc_timeout_cb (gpointer data)
-{
-    WeatherInfo *info = ((MateWeatherApplet *)data)->mateweather_info;
-    update_finish(info, data);
-    return 0;  /* Do not repeat timeout (will be reset by update_finish) */
-}
-
-
 void mateweather_update (MateWeatherApplet *gw_applet)
 {
     WeatherPrefs prefs;

--- a/mateweather/mateweather-applet.h
+++ b/mateweather/mateweather-applet.h
@@ -21,7 +21,6 @@ G_BEGIN_DECLS
 
 extern void mateweather_applet_create(MateWeatherApplet *gw_applet);
 extern gint timeout_cb (gpointer data);
-extern gint suncalc_timeout_cb (gpointer data);
 extern void mateweather_update (MateWeatherApplet *applet);
 
 G_END_DECLS

--- a/mateweather/mateweather-pref.c
+++ b/mateweather/mateweather-pref.c
@@ -318,7 +318,6 @@ static void auto_update_toggled(GtkToggleButton* button, MateWeatherPref* pref)
 {
 	MateWeatherApplet* gw_applet = pref->priv->applet;
 	gboolean toggled;
-	gint nxtSunEvent;
 
 	toggled = gtk_toggle_button_get_active(button);
 	gw_applet->mateweather_pref.update_enabled = toggled;
@@ -330,20 +329,9 @@ static void auto_update_toggled(GtkToggleButton* button, MateWeatherPref* pref)
 		g_source_remove(gw_applet->timeout_tag);
 	}
 
-	if (gw_applet->suncalc_timeout_tag > 0)
-	{
-		g_source_remove(gw_applet->suncalc_timeout_tag);
-	}
-
 	if (gw_applet->mateweather_pref.update_enabled)
 	{
 		gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
-		nxtSunEvent = weather_info_next_sun_event(gw_applet->mateweather_info);
-
-		if (nxtSunEvent >= 0)
-		{
-			gw_applet->suncalc_timeout_tag = g_timeout_add_seconds(nxtSunEvent, suncalc_timeout_cb, gw_applet);
-		}
 	}
 }
 

--- a/mateweather/mateweather.h
+++ b/mateweather/mateweather.h
@@ -38,7 +38,6 @@ typedef struct _MateWeatherApplet {
 	MatePanelAppletOrient orient;
 	gint size;
 	gint timeout_tag;
-	gint suncalc_timeout_tag;
 
 	/* preferences  */
 	MateWeatherPrefs mateweather_pref;


### PR DESCRIPTION
This causes notification spam (if they are enabled) according to: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=823790

A solution is to simply not update on sunrise/sunset (why would you anyways?), here is a patch which does this: https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=823790;filename=bug823790.patch;msg=40
(Issue #231)