### PR TITLE
Two new options for Load graph in Multiload applet

### DIFF
--- a/multiload/docs/C/index.docbook
+++ b/multiload/docs/C/index.docbook
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
+<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
   <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
@@ -7,7 +7,7 @@
   <!ENTITY date "July 2015">
   <!ENTITY applet "System Monitor">
 ]>
-<!-- 
+<!--
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
   http://wiki.mate-desktop.org/dev-doc:doc-team-guide
@@ -19,10 +19,10 @@
 <article id="index" lang="en">
 <!-- please do not change the id; for translations, change lang to -->
 <!-- appropriate code -->
-  <articleinfo> 
-    <title>&applet; Manual</title> 
+  <articleinfo>
+    <title>&applet; Manual</title>
     <abstract role="description">
-      <para>&applet; displays system load information in graphical 
+      <para>&applet; displays system load information in graphical
         format in a panel.</para>
     </abstract>
     <copyright>
@@ -37,11 +37,11 @@
       <year>2004</year>
       <holder>Sun Microsystems</holder>
     </copyright>
-    <copyright> 
-      <year>2003</year> 
-      <year>2004</year> 
-      <holder>Chee Bin HOH</holder> 
-    </copyright> 
+    <copyright>
+      <year>2003</year>
+      <year>2004</year>
+      <holder>Chee Bin HOH</holder>
+    </copyright>
 
 <!-- translators: uncomment this:
     <copyright>
@@ -50,19 +50,19 @@
     </copyright>
 -->
 
-    <publisher role="maintainer"> 
-      <publishername> MATE Documentation Project </publishername> 
-    </publisher> 
+    <publisher role="maintainer">
+      <publishername> MATE Documentation Project </publishername>
+    </publisher>
     <publisher>
       <publishername> GNOME Documentation Project </publishername>
     </publisher>
 
     &legal;
-<!-- This file  contains link to license for the documentation (GNU FDL), and 
-     other legal stuff such as "NO WARRANTY" statement. Please do not change 
+<!-- This file  contains link to license for the documentation (GNU FDL), and
+     other legal stuff such as "NO WARRANTY" statement. Please do not change
      any of this. -->
 
-    <authorgroup> 
+    <authorgroup>
 
       <author>
         <firstname>MATE Documentation Team</firstname>
@@ -80,13 +80,13 @@
 	</address></affiliation>
       </author>
 
-      <author> 
-	<firstname>Chee Bin</firstname> 
-	<surname>HOH</surname> 
-	<affiliation> 
+      <author>
+	<firstname>Chee Bin</firstname>
+	<surname>HOH</surname>
+	<affiliation>
 	  <orgname>GNOME Documentation Project</orgname>
 	  <address><email>cbhoh@mimos.my</email></address>
-	</affiliation> 
+	</affiliation>
       </author>
 
       <author>
@@ -100,17 +100,17 @@
       <!-- This is appropriate place for other contributors: translators,
            maintainers,  etc. Commented out by default.
       <othercredit role="translator">
-        <firstname>Latin</firstname> 
-        <surname>Translator 1</surname> 
-        <affiliation> 
-          <orgname>Latin Translation Team</orgname> 
-          <address> <email>translator@gnome.org</email> </address> 
+        <firstname>Latin</firstname>
+        <surname>Translator 1</surname>
+        <affiliation>
+          <orgname>Latin Translation Team</orgname>
+          <address> <email>translator@gnome.org</email> </address>
         </affiliation>
         <contrib>Latin translation</contrib>
       </othercredit>
 -->
     </authorgroup>
-	
+
 	<releaseinfo revision="1.10.2" role="review"/>
 
     <revhistory>
@@ -130,40 +130,40 @@
 	  <para role="author">Davyd Madeley</para>
 	</revdescription>
       </revision>
-    
+
       <revision>
-	<revnumber>Version 2.8</revnumber> 
-	<date>August 2004</date> 
-	<revdescription> 
+	<revnumber>Version 2.8</revnumber>
+	<date>August 2004</date>
+	<revdescription>
           <para role="author">Angela Boyle</para>
           <para role="publisher">GNOME Documentation Project</para>
-	</revdescription> 
-      </revision> 
+	</revdescription>
+      </revision>
 
-      <revision> 
-	<revnumber>System Monitor Applet Manual V2.1</revnumber> 
-	<date>February 2004</date> 
-	<revdescription> 
+      <revision>
+	<revnumber>System Monitor Applet Manual V2.1</revnumber>
+	<date>February 2004</date>
+	<revdescription>
           <para role="author">Sun GNOME Documentation Team</para>
           <para role="publisher">GNOME Documentation Project</para>
-	</revdescription> 
-      </revision> 
+	</revdescription>
+      </revision>
 
-      <revision> 
-	<revnumber>System Monitor Applet Manual V2.0</revnumber> 
-	<date>July 2003</date> 
-	<revdescription> 
+      <revision>
+	<revnumber>System Monitor Applet Manual V2.0</revnumber>
+	<date>July 2003</date>
+	<revdescription>
 	  <para role="author">Chee Bin HOH
 	    <email>cbhoh@mimos.my</email>
-          </para> 
+          </para>
 	  <para role="publisher">GNOME Documentation Project</para>
-	</revdescription> 
-      </revision> 
+	</revdescription>
+      </revision>
 
-    </revhistory> 
+    </revhistory>
 
     <releaseinfo> This manual describes version &appletversion; of &applet;.
-    </releaseinfo> 
+    </releaseinfo>
     <legalnotice>
       <title>Feedback</title>
       <para> To report a bug or make a suggestion regarding the &applet; applet or this
@@ -173,39 +173,39 @@
     </legalnotice>
   </articleinfo>
 
-  <indexterm zone="index"> 
-    <primary>&applet; Applet</primary> 
-  </indexterm> 
-  <indexterm zone="index"> 
-    <primary>&applet;</primary> 
+  <indexterm zone="index">
+    <primary>&applet; Applet</primary>
+  </indexterm>
+  <indexterm zone="index">
+    <primary>&applet;</primary>
   </indexterm>
 
 <!-- ============= Document Body ============================= -->
 <!-- ============= Introduction ============================== -->
-  <sect1 id="multiload-introduction"> 
-    <title>Introduction</title> 
+  <sect1 id="multiload-introduction">
+    <title>Introduction</title>
 
       <!-- ==== Figure ============================================= -->
-      <figure id="system-monitor-applet-fig"> 
-        <title>&applet;</title> 
-        <screenshot> 
-        <mediaobject> 
+      <figure id="system-monitor-applet-fig">
+        <title>&applet;</title>
+        <screenshot>
+        <mediaobject>
           <imageobject><imagedata fileref="figures/system-monitor-applet_window.png"
-			format="PNG"/> 
+			format="PNG"/>
           </imageobject>
- 	  <textobject> 
+ 	  <textobject>
  	    <phrase>Shows &applet;. Displays a graph for system CPU load.
-            </phrase> 
-          </textobject> 
-        </mediaobject> 
-	</screenshot> 
-      </figure> 
+            </phrase>
+          </textobject>
+        </mediaobject>
+	</screenshot>
+      </figure>
       <!-- ==== End of Figure ======================================= -->
 
       <para>
         The <application>&applet;</application> displays
         system load information in graphical format in a panel.
-        You can configure <application>&applet;</application> to display 
+        You can configure <application>&applet;</application> to display
         the following information for your system:
       </para>
       <itemizedlist>
@@ -221,45 +221,45 @@
         </listitem>
         <listitem>
           <para>
-            Network traffic 
+            Network traffic
           </para>
         </listitem>
         <listitem>
           <para>
-            Usage of swap space 
+            Usage of swap space
           </para>
         </listitem>
         <listitem>
           <para>
-            Average system load 
+            Average system load
           </para>
         </listitem>
 	<listitem><para>Disk load</para></listitem>
       </itemizedlist>
 
-      <sect2 id="multiload-introduction-add"> 
-        <title>To Add &applet; to a Panel</title> 
+      <sect2 id="multiload-introduction-add">
+        <title>To Add &applet; to a Panel</title>
 	<para>To add <application>&applet;</application> to a panel,
 	right-click on the panel, then choose <guimenuitem>Add to
 	Panel</guimenuitem>.  Select <application>&applet;</application>
 	in the <application>Add to the panel</application> dialog, then
 	click <guibutton>OK</guibutton>.</para>
         <para>
-          The layout of the <application>&applet;</application> varies 
+          The layout of the <application>&applet;</application> varies
           depending on the size and type of panel in which the applet resides.
-        </para>     
+        </para>
       </sect2>
 
   </sect1>
 
 <!-- ================ Usage ================================ -->
-<!-- Use this section to describe how to use the applet to perform the tasks for 
+<!-- Use this section to describe how to use the applet to perform the tasks for
      which the applet is designed. -->
-  <sect1 id="multiload-usage"> 
-    <title>Viewing Graphs</title> 
+  <sect1 id="multiload-usage">
+    <title>Viewing Graphs</title>
 	<!-- ================ displaying addistional graphics======================== -->
-    <sect2 id="multiload-usage-graphs"> 
-      <title>Displaying Additional Graphs</title> 
+    <sect2 id="multiload-usage-graphs">
+      <title>Displaying Additional Graphs</title>
       <para>To configure the <application>&applet;</application> applet, right-click on the applet, then choose <guimenuitem>Preferences</guimenuitem>. Under <guilabel>Monitored Resources</guilabel> you can choose which graphics you want to display:</para>
           <itemizedlist>
             <listitem>
@@ -311,26 +311,26 @@
           </itemizedlist>
     </sect2>
 	<!-- ================ displaying current usage of system resources================== -->
-    <sect2 id="multiload-usage-current"> 
-      <title>To Display the Current Usage of a System Resource</title> 
+    <sect2 id="multiload-usage-current">
+      <title>To Display the Current Usage of a System Resource</title>
       <para>
-        To display the current usage of a system resource, 
+        To display the current usage of a system resource,
         position the mouse pointer over the corresponding graph in the applet.
         A tooltip displays the current usage as a percentage.
       </para>
     </sect2>
 	<!-- ================ displaying additional info================== -->
-    <sect2 id="multiload-usage-extra"> 
+    <sect2 id="multiload-usage-extra">
       <title>To Display Additional System Monitor Information</title>
       <para>
-        To display additional system monitor information, right-click on the applet, 
+        To display additional system monitor information, right-click on the applet,
         then choose <guimenuitem>Open System Monitor</guimenuitem> to start the
-        <application>System Monitor</application> application. 
+        <application>System Monitor</application> application.
       </para>
       <para>
-        The <application>System Monitor</application> application 
+        The <application>System Monitor</application> application
         enables you to monitor system processes and usage of system resources.
-        You can use the <application>System Monitor</application> application 
+        You can use the <application>System Monitor</application> application
         to modify the behavior of your system.
       </para>
     </sect2>
@@ -339,21 +339,21 @@
 
 <!-- ============= Preferences =========================== -->
   <sect1 id="multiload-prefs">
-    <title>Customizing Appearance</title> 
-      <figure id="system-monitor-prefs-fig"> 
-        <title>Preferences Dialog</title> 
-        <screenshot> 
-        <mediaobject> 
+    <title>Customizing Appearance</title>
+      <figure id="system-monitor-prefs-fig">
+        <title>Preferences Dialog</title>
+        <screenshot>
+        <mediaobject>
           <imageobject><imagedata fileref="figures/multiload-preferences.png"
-			format="PNG"/> 
+			format="PNG"/>
           </imageobject>
- 	  <textobject> 
+ 	  <textobject>
  	    <phrase>Preferences Dialog
-            </phrase> 
-          </textobject> 
-        </mediaobject> 
-	</screenshot> 
-      </figure> 
+            </phrase>
+          </textobject>
+        </mediaobject>
+	</screenshot>
+      </figure>
     <sect2 id="multiload-size">
         <title>To Change the Width</title>
               <para>In the right-click menu, go to <guimenuitem>Preferences</guimenuitem>. Under <guilabel>Options</guilabel>, use the <guilabel>System monitor width</guilabel> spin box to specify the width of each <application>&applet;</application> graph in pixels.</para>
@@ -363,8 +363,18 @@
               <para>In the right-click menu, go to <guimenuitem>Preferences</guimenuitem>. Under <guilabel>Options</guilabel>, use the <guilabel>System monitor update interval</guilabel> spin box to specify the interval at which you want to update the graphs in milliseconds.
               </para>
     </sect2>
+    <sect2 id="multiload-maxload">
+          <title>To Change the Maximum Value in Load Graph</title>
+                <para>In the right-click menu, go to <guimenuitem>Preferences</guimenuitem>. Under <guilabel>Options</guilabel>, use the <guilabel>Maximum loadavg per CPU</guilabel> spin box to specify maximum load value per CPU for Load graph scaling.
+                </para>
+      </sect2>
+      <sect2 id="multiload-multiCPU">
+            <title>To Select whether multiple CPUs should be taken into account</title>
+                  <para>In the right-click menu, go to <guimenuitem>Preferences</guimenuitem>. Under <guilabel>Options</guilabel>, use the <guilabel>MultiCPU calculation for load average</guilabel> check box to specify whether Load graph scaling should take into account number of CPUs.
+                  </para>
+        </sect2>
 	<!-- ================ changing graph colors======================== -->
-    <sect2 id="multiload-usage-colors"> 
+    <sect2 id="multiload-usage-colors">
       <title>Changing the Colors in a Graph</title>
       <para>
         To change the colors in a graph, perform the following steps:

--- a/multiload/global.h
+++ b/multiload/global.h
@@ -61,20 +61,20 @@ struct _LoadGraph {
 struct _MultiloadApplet
 {
 	MatePanelApplet *applet;
-
+	
 	GSettings *settings;
-
+	
 	LoadGraph *graphs[NGRAPHS];
-
+	
 	GtkWidget *box;
-
+	
 	gboolean view_cpuload;
 	gboolean view_memload;
 	gboolean view_netload;
 	gboolean view_swapload;
 	gboolean view_loadavg;
 	gboolean view_diskload;
-
+	
 	GtkWidget *about_dialog;
 	GtkWidget *check_boxes[NGRAPHS];
 	GtkWidget *prop_dialog;

--- a/multiload/global.h
+++ b/multiload/global.h
@@ -24,6 +24,9 @@ struct _LoadGraph {
 
     guint n, id;
     guint speed, size;
+    guint maxload;
+    gboolean show_multiproc;
+
     guint orient, pixel_size;
     guint draw_width, draw_height;
     LoadGraphDataFunc get_data;
@@ -58,20 +61,20 @@ struct _LoadGraph {
 struct _MultiloadApplet
 {
 	MatePanelApplet *applet;
-	
+
 	GSettings *settings;
-	
+
 	LoadGraph *graphs[NGRAPHS];
-	
+
 	GtkWidget *box;
-	
+
 	gboolean view_cpuload;
 	gboolean view_memload;
 	gboolean view_netload;
 	gboolean view_swapload;
 	gboolean view_loadavg;
 	gboolean view_diskload;
-	
+
 	GtkWidget *about_dialog;
 	GtkWidget *check_boxes[NGRAPHS];
 	GtkWidget *prop_dialog;

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -53,9 +53,9 @@ GetLoad (int Maximum, int data [5], LoadGraph *g)
     int total;
 
     glibtop_cpu cpu;
-	
+
     glibtop_get_cpu (&cpu);
-	
+
     g_return_if_fail ((cpu.flags & needed_cpu_flags) == needed_cpu_flags);
 
     g->cpu_time [0] = cpu.user;
@@ -162,9 +162,9 @@ GetPage (int Maximum, int data [3], LoadGraph *g)
     int in, out, idle;
 
     glibtop_swap swap;
-	
+
     glibtop_get_swap (&swap);
-	
+
     assert ((swap.flags & needed_page_flags) == needed_page_flags);
 
     if ((lastin > 0) && (lastin < swap.pagein)) {
@@ -204,18 +204,18 @@ void
 GetMemory (int Maximum, int data [5], LoadGraph *g)
 {
     int user, shared, buffer, cached;
-    
+
     glibtop_mem mem;
-	
+
     glibtop_get_mem (&mem);
-	
+
     g_return_if_fail ((mem.flags & needed_mem_flags) == needed_mem_flags);
 
     user    = rint (Maximum * (float)mem.user / (float)mem.total);
     shared  = rint (Maximum * (float)mem.shared / (float)mem.total);
     buffer  = rint (Maximum * (float)mem.buffer / (float)mem.total);
     cached = rint (Maximum * (float)mem.cached / (float)mem.total);
-    
+
     data [0] = user;
     data [1] = shared;
     data [2] = buffer;
@@ -247,8 +247,31 @@ GetSwap (int Maximum, int data [2], LoadGraph *g)
 void
 GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 {
-    const float per_cpu_max_loadavg = 5.0f;
-    float max_loadavg;
+
+const float per_cpu_max_loadavg = g->maxload;
+float max_loadavg;
+float loadavg1;
+float used;
+
+glibtop_loadavg loadavg;
+glibtop_get_loadavg (&loadavg);
+
+g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
+
+if (g->show_multiproc == TRUE )
+  max_loadavg = per_cpu_max_loadavg * (1 + glibtop_global_server->ncpu);
+else
+  max_loadavg = per_cpu_max_loadavg;
+
+g->loadavg1 = loadavg.loadavg[0];
+loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
+
+used    = loadavg1 / max_loadavg;
+
+data [0] = rint ((float) Maximum * used);
+data [1] = Maximum - data[0];
+/*
+    float max_loadavg = 2.0f;
     float loadavg1;
     float used;
 
@@ -257,8 +280,6 @@ GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 
     g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
 
-    max_loadavg = per_cpu_max_loadavg * (1 + glibtop_global_server->ncpu);
-
     g->loadavg1 = loadavg.loadavg[0];
     loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
 
@@ -266,6 +287,7 @@ GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 
     data [0] = rint ((float) Maximum * used);
     data [1] = Maximum - data[0];
+    */
 }
 
 /*
@@ -405,6 +427,3 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
 
     memcpy(past, present, sizeof past);
 }
-
-
-

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -248,46 +248,28 @@ void
 GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 {
 
-const float per_cpu_max_loadavg = g->maxload;
-float max_loadavg;
-float loadavg1;
-float used;
+	const float per_cpu_max_loadavg = g->maxload;
+	float max_loadavg;
+	float loadavg1;
+	float used;
 
-glibtop_loadavg loadavg;
-glibtop_get_loadavg (&loadavg);
+	glibtop_loadavg loadavg;
+	glibtop_get_loadavg (&loadavg);
 
-g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
+	g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
 
-if (g->show_multiproc == TRUE )
-  max_loadavg = per_cpu_max_loadavg * (1 + glibtop_global_server->ncpu);
-else
-  max_loadavg = per_cpu_max_loadavg;
+	if (g->show_multiproc == TRUE )
+	  max_loadavg = per_cpu_max_loadavg * (1 + glibtop_global_server->ncpu);
+	else
+	  max_loadavg = per_cpu_max_loadavg;
 
-g->loadavg1 = loadavg.loadavg[0];
-loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
+	g->loadavg1 = loadavg.loadavg[0];
+	loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
 
-used    = loadavg1 / max_loadavg;
+	used    = loadavg1 / max_loadavg;
 
-data [0] = rint ((float) Maximum * used);
-data [1] = Maximum - data[0];
-/*
-    float max_loadavg = 2.0f;
-    float loadavg1;
-    float used;
-
-    glibtop_loadavg loadavg;
-    glibtop_get_loadavg (&loadavg);
-
-    g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
-
-    g->loadavg1 = loadavg.loadavg[0];
-    loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
-
-    used    = loadavg1 / max_loadavg;
-
-    data [0] = rint ((float) Maximum * used);
-    data [1] = Maximum - data[0];
-    */
+	data [0] = rint ((float) Maximum * used);
+	data [1] = Maximum - data[0];
 }
 
 /*

--- a/multiload/main.c
+++ b/multiload/main.c
@@ -374,6 +374,10 @@ multiload_create_graphs(MultiloadApplet *ma)
 	speed = MAX (speed, 50);
 	size = CLAMP (size, 10, 400);
 
+	maxload = g_settings_get_int (ma->settings, "loadavgmax");
+	show_multiproc = g_settings_get_boolean (ma->settings, "show-multiproc");
+	maxload = MIN (maxload, 10);
+
 	for (i = 0; i < G_N_ELEMENTS (graph_types); i++)
 	{
 		gboolean visible;
@@ -399,13 +403,11 @@ multiload_create_graphs(MultiloadApplet *ma)
 						visible,
 						graph_types[i].name,
 						graph_types[i].callback);
+		if (i == PROP_AVG) {
+			ma->graphs[PROP_AVG]->maxload = maxload;
+			ma->graphs[PROP_AVG]->show_multiproc = show_multiproc;
+		}
 	}
-	maxload = g_settings_get_int (ma->settings, "loadavgmax");
-	show_multiproc = g_settings_get_boolean (ma->settings, "show-multiproc");
-	maxload = MAX (maxload, 10);
-  ma->graphs[PROP_AVG]->maxload = maxload;
-	ma->graphs[PROP_AVG]->show_multiproc = show_multiproc;
-
 }
 
 /* remove the old graphs and rebuild them */

--- a/multiload/org.mate.panel.applet.multiload.gschema.xml.in
+++ b/multiload/org.mate.panel.applet.multiload.gschema.xml.in
@@ -33,6 +33,14 @@
       <summary>Graph size</summary>
       <description>For horizontal panels, the width of the graphs in pixels.  For vertical panels, this is the height of the graphs.</description>
     </key>
+    <key name="loadavgmax" type="i">
+      <default>5</default>
+      <summary>Maximum average load per CPU (graph scaling)</summary>
+    </key>
+    <key name="show-multiproc" type="b">
+      <default>true</default>
+      <summary>Take number of processors into account in showing load average</summary>
+    </key>
     <key name="cpuload-color0" type="s">
       <default>'#0072b3'</default>
       <summary>Graph color for user-related CPU activity</summary>


### PR DESCRIPTION
For load average original code calculated maximum y-axis in graph as 5 * (numcpu+1). If you have 4 CPUs it is 25. If your average load (as shown it 'top') is 1.5 (which is something I would like to see clearly in the graph) it is just 1-2 pixels at the bottom. Only if your load goes to 4-5 is is clearly visible in Load graph.
This code introduced two new options - you can select multiplication factor from 1 to 10 (which was 5 in original code). And the second option allows to ignore number of processors. 
It means if I set maximum to 2 and disable multicpu option, I can see average load graph nicely even when my load is below 1. It will max out at 2.
Defaults are set to keep the original behavior. 