### PR TITLE
Autoscale load

### DIFF
--- a/multiload/docs/C/index.docbook
+++ b/multiload/docs/C/index.docbook
@@ -602,6 +602,10 @@
 		     <entry><para><guilabel>Background</guilabel></para></entry>
 		     <entry><para>that is, no load</para></entry>
 		    </row>
+		    <row valign="top">
+		     <entry><para><guilabel>Grid line</guilabel></para></entry>
+		     <entry><para>Color of grid lines</para></entry>
+		    </row>
 		  </tbody>
 		</tgroup>
 	      </informaltable>

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -53,9 +53,9 @@ GetLoad (int Maximum, int data [5], LoadGraph *g)
     int total;
 
     glibtop_cpu cpu;
-	
+
     glibtop_get_cpu (&cpu);
-	
+
     g_return_if_fail ((cpu.flags & needed_cpu_flags) == needed_cpu_flags);
 
     g->cpu_time [0] = cpu.user;
@@ -162,9 +162,9 @@ GetPage (int Maximum, int data [3], LoadGraph *g)
     int in, out, idle;
 
     glibtop_swap swap;
-	
+
     glibtop_get_swap (&swap);
-	
+
     assert ((swap.flags & needed_page_flags) == needed_page_flags);
 
     if ((lastin > 0) && (lastin < swap.pagein)) {
@@ -204,18 +204,18 @@ void
 GetMemory (int Maximum, int data [5], LoadGraph *g)
 {
     int user, shared, buffer, cached;
-    
+
     glibtop_mem mem;
-	
+
     glibtop_get_mem (&mem);
-	
+
     g_return_if_fail ((mem.flags & needed_mem_flags) == needed_mem_flags);
 
     user    = rint (Maximum * (float)mem.user / (float)mem.total);
     shared  = rint (Maximum * (float)mem.shared / (float)mem.total);
     buffer  = rint (Maximum * (float)mem.buffer / (float)mem.total);
     cached = rint (Maximum * (float)mem.cached / (float)mem.total);
-    
+
     data [0] = user;
     data [1] = shared;
     data [2] = buffer;
@@ -247,9 +247,6 @@ GetSwap (int Maximum, int data [2], LoadGraph *g)
 void
 GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 {
-    const float per_cpu_max_loadavg = 5.0f;
-    float max_loadavg;
-    float loadavg1;
     float used;
 
     glibtop_loadavg loadavg;
@@ -257,14 +254,10 @@ GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 
     g_return_if_fail ((loadavg.flags & needed_loadavg_flags) == needed_loadavg_flags);
 
-    max_loadavg = per_cpu_max_loadavg * (1 + glibtop_global_server->ncpu);
-
+    /* g->loadavg1 represents %used */
     g->loadavg1 = loadavg.loadavg[0];
-    loadavg1 = MIN(loadavg.loadavg[0], max_loadavg);
 
-    used    = loadavg1 / max_loadavg;
-
-    data [0] = rint ((float) Maximum * used);
+    data [0] = rint ((float) Maximum * g->loadavg1);
     data [1] = Maximum - data[0];
 }
 
@@ -405,6 +398,3 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
 
     memcpy(past, present, sizeof past);
 }
-
-
-

--- a/multiload/load-graph.c
+++ b/multiload/load-graph.c
@@ -12,6 +12,7 @@
 #include <gio/gio.h>
 #include <mate-panel-applet.h>
 #include <mate-panel-applet-gsettings.h>
+#include <math.h>
 
 #include "global.h"
 
@@ -37,7 +38,7 @@ shift_right(LoadGraph *g)
 
 	/* data[i+1] = data[i] */
 	for(i = g->draw_width - 1; i != 0; --i)
-		g->data[i] = g->data[i-1];
+		g->data[i] = g->data[i - 1];
 
 	g->data[0] = last_data;
 }
@@ -47,44 +48,93 @@ shift_right(LoadGraph *g)
 static void
 load_graph_draw (LoadGraph *g)
 {
-    guint i, j;
-    cairo_t *cr;
+  guint i, j, k;
+  cairo_t *cr;
+  int load;
 
-    /* we might get called before the configure event so that
-     * g->disp->allocation may not have the correct size
-     * (after the user resized the applet in the prop dialog). */
+  /* we might get called before the configure event so that
+   * g->disp->allocation may not have the correct size
+   * (after the user resized the applet in the prop dialog). */
 
-    if (!g->surface)
-		g->surface = gdk_window_create_similar_surface (gtk_widget_get_window (g->disp),
-								CAIRO_CONTENT_COLOR,
-								g->draw_width, g->draw_height);
+  if (!g->surface)
+    g->surface = gdk_window_create_similar_surface (gtk_widget_get_window (g->disp),
+                                                    CAIRO_CONTENT_COLOR,
+                                                    g->draw_width, g->draw_height);
 
-    cr = cairo_create (g->surface);
-    cairo_set_line_width (cr, 1.0);
-    cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
-    cairo_set_line_join (cr, CAIRO_LINE_JOIN_ROUND);
+  cr = cairo_create (g->surface);
+  cairo_set_line_width (cr, 1.0);
+  cairo_set_line_cap (cr, CAIRO_LINE_CAP_ROUND);
+  cairo_set_line_join (cr, CAIRO_LINE_JOIN_ROUND);
 
+  /* all graphs except Load go this path */
+  if (g->id != 4)
+  {
     for (i = 0; i < g->draw_width; i++)
-		g->pos [i] = g->draw_height - 1;
+      g->pos [i] = g->draw_height - 1;
 
     for (j = 0; j < g->n; j++)
     {
-		gdk_cairo_set_source_rgba (cr, &(g->colors [j]));
+      gdk_cairo_set_source_rgba (cr, &(g->colors [j]));
 
-		for (i = 0; i < g->draw_width; i++) {
-			if (g->data [i][j] != 0) {
-				cairo_move_to (cr, g->draw_width - i - 0.5, g->pos[i] + 0.5);
-				cairo_line_to (cr, g->draw_width - i - 0.5, g->pos[i] - (g->data [i][j] - 0.5));
-
-				g->pos [i] -= g->data [i][j];
-			}
-		}
-		cairo_stroke (cr);
+      for (i = 0; i < g->draw_width; i++)
+      {
+        if (g->data [i][j] != 0)
+        {
+          cairo_move_to (cr, g->draw_width - i - 0.5, g->pos[i] + 0.5);
+          cairo_line_to (cr, g->draw_width - i - 0.5, g->pos[i] - (g->data [i][j] - 0.5));
+        }
+        g->pos [i] -= g->data [i][j];
+      }
+      cairo_stroke (cr);
     }
 
-    gtk_widget_queue_draw (g->disp);
+  }
+  /* this is Load graph */
+  else
+  {
+    guint maxload =	1;
+    for (i = 0; i < g->draw_width; i++)
+    {
+      g->pos [i] = g->draw_height - 1;
+      /* find maximum value */
+      if (g->data[i][0] > maxload)
+        maxload = g->data[i][0];
+    }
+    load = ceil ((double) (maxload/g->draw_height)) + 1;
+    load = MAX (load,1);
 
-    cairo_destroy (cr);
+    for (j = 0; j < g->n; j++)
+    {
+      gdk_cairo_set_source_rgba (cr, &(g->colors [j]));
+
+      for (i = 0; i < g->draw_width; i++)
+      {
+        cairo_move_to (cr, g->draw_width - i - 0.5, g->pos[i] + 0.5);
+        if (j == 0)
+        {
+          cairo_line_to (cr, g->draw_width - i - 0.5, g->pos[i] - ((g->data [i][j] - 0.5)/load));
+        }
+        else
+        {
+          cairo_line_to (cr, g->draw_width - i - 0.5, 0.5);
+        }
+        g->pos [i] -= g->data [i][j] / load;
+      }
+      cairo_stroke (cr);
+    }
+
+    /* draw grid lines in Load graph if needed */
+    gdk_cairo_set_source_rgba (cr, &(g->colors [2]));
+    for (k = 0; k < load - 1; k++)
+    {
+      cairo_move_to (cr, 0.5, (g->draw_height/load)*(k+1));
+      cairo_line_to (cr, g->draw_width-0.5, (g->draw_height/load)*(k+1));
+    }
+    cairo_stroke (cr);
+  }
+  gtk_widget_queue_draw (g->disp);
+
+  cairo_destroy (cr);
 }
 
 /* Updates the load graph when the timeout expires */
@@ -123,7 +173,7 @@ load_graph_unalloc (LoadGraph *g)
 
     g->pos = NULL;
     g->data = NULL;
-    
+
     g->size = g_settings_get_int(g->multiload->settings, "size");
     g->size = MAX (g->size, 10);
 
@@ -161,7 +211,7 @@ load_graph_configure (GtkWidget *widget, GdkEventConfigure *event,
 {
     GtkAllocation allocation;
     LoadGraph *c = (LoadGraph *) data_ptr;
-    
+
     load_graph_unalloc (c);
 
     gtk_widget_get_allocation (c->disp, &allocation);
@@ -170,7 +220,7 @@ load_graph_configure (GtkWidget *widget, GdkEventConfigure *event,
     c->draw_height = allocation.height;
     c->draw_width = MAX (c->draw_width, 1);
     c->draw_height = MAX (c->draw_height, 1);
-    
+
     load_graph_alloc (c);
 
     if (!c->surface)
@@ -246,7 +296,7 @@ load_graph_load_config (LoadGraph *g)
 
 	if (!g->colors)
 		g->colors = g_new0(GdkRGBA, g->n);
-		
+
 	for (i = 0; i < g->n; i++)
 	{
 		name = g_strdup_printf ("%s-color%u", g->name, i);
@@ -261,12 +311,12 @@ load_graph_load_config (LoadGraph *g)
 
 LoadGraph *
 load_graph_new (MultiloadApplet *ma, guint n, const gchar *label,
-		guint id, guint speed, guint size, gboolean visible, 
+		guint id, guint speed, guint size, gboolean visible,
 		const gchar *name, LoadGraphDataFunc get_data)
 {
     LoadGraph *g;
     MatePanelAppletOrient orient;
-    
+
     g = g_new0 (LoadGraph, 1);
     g->netspeed_in = netspeed_new(g);
     g->netspeed_out = netspeed_new(g);
@@ -280,11 +330,11 @@ load_graph_new (MultiloadApplet *ma, guint n, const gchar *label,
     g->tooltip_update = FALSE;
     g->show_frame = TRUE;
     g->multiload = ma;
-		
+
     g->main_widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
     g->box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-    
+
     orient = mate_panel_applet_get_orient (g->multiload->applet);
     switch (orient)
     {
@@ -303,7 +353,7 @@ load_graph_new (MultiloadApplet *ma, guint n, const gchar *label,
     default:
 	g_assert_not_reached ();
     }
-    
+
     if (g->show_frame)
     {
 	g->frame = gtk_frame_new (NULL);
@@ -333,7 +383,7 @@ load_graph_new (MultiloadApplet *ma, guint n, const gchar *label,
 				    GDK_ENTER_NOTIFY_MASK |
     				    GDK_LEAVE_NOTIFY_MASK |
 				    GDK_BUTTON_PRESS_MASK);
-	
+
     g_signal_connect (G_OBJECT (g->disp), "draw",
 			G_CALLBACK (load_graph_expose), g);
     g_signal_connect (G_OBJECT(g->disp), "configure_event",
@@ -346,8 +396,8 @@ load_graph_new (MultiloadApplet *ma, guint n, const gchar *label,
                       G_CALLBACK(load_graph_enter_cb), g);
     g_signal_connect (G_OBJECT(g->disp), "leave-notify-event",
                       G_CALLBACK(load_graph_leave_cb), g);
-	
-    gtk_box_pack_start (GTK_BOX (g->box), g->disp, TRUE, TRUE, 0);    
+
+    gtk_box_pack_start (GTK_BOX (g->box), g->disp, TRUE, TRUE, 0);
     gtk_widget_show_all(g->box);
 
     return g;
@@ -368,6 +418,6 @@ load_graph_stop (LoadGraph *g)
 {
     if (g->timer_index != -1)
 		g_source_remove (g->timer_index);
-    
+
     g->timer_index = -1;
 }

--- a/multiload/main.c
+++ b/multiload/main.c
@@ -72,7 +72,7 @@ help_cb (GtkAction       *action,
 {
 
  	GError *error = NULL;
-                                                                                
+
 	gtk_show_uri (gtk_widget_get_screen (GTK_WIDGET (ma->applet)),
 			"help:mate-multiload",
 			gtk_get_current_event_time (),
@@ -160,7 +160,7 @@ start_procman (MultiloadApplet *ma)
 		g_error_free (error);
 	}
 }
-              
+
 static void
 start_procman_cb (GtkAction       *action,
 		  MultiloadApplet *ma)
@@ -172,9 +172,9 @@ static void
 multiload_change_size_cb(MatePanelApplet *applet, gint size, gpointer data)
 {
 	MultiloadApplet *ma = (MultiloadApplet *)data;
-	
+
 	multiload_applet_refresh(ma);
-	
+
 	return;
 }
 
@@ -183,7 +183,7 @@ multiload_change_orient_cb(MatePanelApplet *applet, gint arg1, gpointer data)
 {
 	MultiloadApplet *ma = data;
 	multiload_applet_refresh((MultiloadApplet *)data);
-	gtk_widget_show (GTK_WIDGET (ma->applet));		
+	gtk_widget_show (GTK_WIDGET (ma->applet));
 	return;
 }
 
@@ -202,14 +202,14 @@ multiload_destroy_cb(GtkWidget *widget, gpointer data)
 			ma->graphs[i]->colors = NULL;
 		}
 		gtk_widget_destroy(ma->graphs[i]->main_widget);
-	
+
 		load_graph_unalloc(ma->graphs[i]);
 		g_free(ma->graphs[i]);
 	}
-	
+
 	if (ma->about_dialog)
 		gtk_widget_destroy (ma->about_dialog);
-	
+
 	if (ma->prop_dialog)
 		gtk_widget_destroy (ma->prop_dialog);
 
@@ -284,7 +284,7 @@ multiload_applet_tooltip_update(LoadGraph *g)
 		name = g_strdup(_("Disk"));
 	else
 		g_assert_not_reached();
-	
+
 	if (!strncmp(g->name, "memload", strlen("memload"))) {
 		guint mem_user, mem_cache, user_percent, cache_percent;
 		mem_user  = g->data[0][0];
@@ -341,7 +341,7 @@ multiload_applet_tooltip_update(LoadGraph *g)
 	}
 
 	gtk_widget_set_tooltip_text(g->disp, tooltip_text);
-		
+
 	g_free(tooltip_text);
 	g_free(name);
 }
@@ -358,7 +358,7 @@ multiload_create_graphs(MultiloadApplet *ma)
 			{ _("Memory Load"),  "memload",  5, GetMemory },
 			{ _("Net Load"),     "netload2",  4, GetNet },
 			{ _("Swap Load"),    "swapload", 2, GetSwap },
-			{ _("Load Average"), "loadavg",  2, GetLoadAvg },
+			{ _("Load Average"), "loadavg",  3, GetLoadAvg },
 			{ _("Disk Load"),    "diskload", 3, GetDiskLoad }
 		};
 
@@ -396,6 +396,8 @@ multiload_create_graphs(MultiloadApplet *ma)
 						graph_types[i].name,
 						graph_types[i].callback);
 	}
+    /* for Load graph, colors[2] is grid line color, it should not be used in loop in load-graph.c */
+    ma->graphs[4]->n = 2;
 }
 
 /* remove the old graphs and rebuild them */
@@ -410,36 +412,36 @@ multiload_applet_refresh(MultiloadApplet *ma)
 	{
 		if (!ma->graphs[i])
 			continue;
-			
+
 		load_graph_stop(ma->graphs[i]);
 		gtk_widget_destroy(ma->graphs[i]->main_widget);
-		
+
 		load_graph_unalloc(ma->graphs[i]);
 		g_free(ma->graphs[i]);
 	}
 
 	if (ma->box)
 		gtk_widget_destroy(ma->box);
-	
+
 	orientation = mate_panel_applet_get_orient(ma->applet);
-	
-	if ( (orientation == MATE_PANEL_APPLET_ORIENT_UP) || 
+
+	if ( (orientation == MATE_PANEL_APPLET_ORIENT_UP) ||
 	     (orientation == MATE_PANEL_APPLET_ORIENT_DOWN) ) {
 		ma->box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	}
 	else
 		ma->box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-	
+
 	gtk_container_add(GTK_CONTAINER(ma->applet), ma->box);
-			
+
 	/* create the NGRAPHS graphs, passing in their user-configurable properties with gsettings. */
 	multiload_create_graphs (ma);
 
 	/* only start and display the graphs the user has turned on */
 
 	for (i = 0; i < NGRAPHS; i++) {
-	    gtk_box_pack_start(GTK_BOX(ma->box), 
-			       ma->graphs[i]->main_widget, 
+	    gtk_box_pack_start(GTK_BOX(ma->box),
+			       ma->graphs[i]->main_widget,
 			       TRUE, TRUE, 1);
 	    if (ma->graphs[i]->visible) {
 	    	gtk_widget_show_all (ma->graphs[i]->main_widget);
@@ -447,7 +449,7 @@ multiload_applet_refresh(MultiloadApplet *ma)
 	    }
 	}
 	gtk_widget_show (ma->box);
-			
+
 	return;
 }
 
@@ -464,7 +466,7 @@ static const GtkActionEntry multiload_menu_actions [] = {
 	{ "MultiLoadAbout", GTK_STOCK_ABOUT, N_("_About"),
 	  NULL, NULL,
 	  G_CALLBACK (about_cb) }
-};		
+};
 
 /* create a box and stuff the load graphs inside of it */
 static gboolean
@@ -474,11 +476,11 @@ multiload_applet_new(MatePanelApplet *applet, const gchar *iid, gpointer data)
 	GSettings *lockdown_settings;
 	GtkActionGroup *action_group;
 	gchar *ui_path;
-	
+
 	ma = g_new0(MultiloadApplet, 1);
-	
+
 	ma->applet = applet;
-	
+
 	ma->about_dialog = NULL;
 	ma->prop_dialog = NULL;
         ma->last_clicked = 0;
@@ -487,7 +489,7 @@ multiload_applet_new(MatePanelApplet *applet, const gchar *iid, gpointer data)
 
 	gtk_window_set_default_icon_name ("utilities-system-monitor");
 	mate_panel_applet_set_background_widget (applet, GTK_WIDGET(applet));
-	
+
 	ma->settings = mate_panel_applet_settings_new (applet, "org.mate.panel.applet.multiload");
 	mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 
@@ -533,11 +535,11 @@ multiload_applet_new(MatePanelApplet *applet, const gchar *iid, gpointer data)
 				G_CALLBACK(multiload_button_press_event_cb), ma);
 	g_signal_connect(G_OBJECT(applet), "key_press_event",
 				G_CALLBACK(multiload_key_press_event_cb), ma);
-	
+
 	multiload_applet_refresh (ma);
-		
+
 	gtk_widget_show(GTK_WIDGET(applet));
-			
+
 	return TRUE;
 }
 
@@ -547,11 +549,11 @@ multiload_factory (MatePanelApplet *applet,
 				gpointer data)
 {
 	gboolean retval = FALSE;
-	
+
 	glibtop_init();
 
 	retval = multiload_applet_new(applet, iid, data);
-	
+
 	return retval;
 }
 

--- a/multiload/org.mate.panel.applet.multiload.gschema.xml.in
+++ b/multiload/org.mate.panel.applet.multiload.gschema.xml.in
@@ -105,6 +105,10 @@
       <default>'#000000'</default>
       <summary>Load graph background color</summary>
     </key>
+    <key name="loadavg-color2" type="s">
+      <default>'#ffffff'</default>
+      <summary>Grid line color</summary>
+    </key>
     <key name="diskload-color0" type="s">
       <default>'#C65000'</default>
       <summary>Graph color for disk read</summary>

--- a/multiload/properties.c
+++ b/multiload/properties.c
@@ -1,7 +1,7 @@
 /* MATE cpuload/memload panel applet
  * (C) 2002 The Free Software Foundation
  *
- * Authors: 
+ * Authors:
  *		  Todd Kulesza
  *
  *
@@ -57,20 +57,20 @@ static void
 properties_set_insensitive(MultiloadApplet *ma)
 {
 	gint i, total_graphs, last_graph;
-	
+
 	total_graphs = 0;
 	last_graph = 0;
-		
+
 	for (i = 0; i < NGRAPHS; i++)
 		if (ma->graphs[i]->visible)
 		{
 			last_graph = i;
 			total_graphs++;
 		}
-			
+
 	if (total_graphs < 2)
 		soft_set_sensitive(ma->check_boxes[last_graph], FALSE);
-		
+
 	return;
 }
 
@@ -94,7 +94,7 @@ properties_close_cb (GtkWidget *widget, gint arg, MultiloadApplet *ma)
 				error = NULL;
 			}
 			break;
-			
+
 		case GTK_RESPONSE_CLOSE:
 		default:
 			gtk_widget_destroy (widget);
@@ -108,19 +108,19 @@ property_toggled_cb(GtkWidget *widget, gpointer name)
 	MultiloadApplet *ma;
 	gint prop_type, i;
 	gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-	
+
 	ma = g_object_get_data(G_OBJECT(widget), "MultiloadApplet");
 	prop_type = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "prop_type"));
-	
+
 	/* FIXME: the first toggle button to be checked/dechecked does not work, but after that everything is cool.  what gives? */
 	/* FIXME: check if this is still valid for gsettings */
 	g_settings_set_boolean (ma->settings, (gchar *)name, active);
 	g_settings_set_boolean (ma->settings, (gchar *)name, active);
-	
+
 	if (active)
 	{
 		for (i = 0; i < NGRAPHS; i++)
-			soft_set_sensitive(ma->check_boxes[i], TRUE);	
+			soft_set_sensitive(ma->check_boxes[i], TRUE);
 		gtk_widget_show_all (ma->graphs[prop_type]->main_widget);
 		ma->graphs[prop_type]->visible = TRUE;
 		load_graph_start(ma->graphs[prop_type]);
@@ -132,7 +132,7 @@ property_toggled_cb(GtkWidget *widget, gpointer name)
 		ma->graphs[prop_type]->visible = FALSE;
 		properties_set_insensitive(ma);
 	}
-	
+
 	return;
 }
 
@@ -141,15 +141,15 @@ spin_button_changed_cb(GtkWidget *widget, gpointer name)
 {
 	MultiloadApplet *ma;
 	gint value, prop_type, i;
-	
+
 	ma = g_object_get_data(G_OBJECT(widget), "MultiloadApplet");
 	prop_type = GPOINTER_TO_INT(g_object_get_data(G_OBJECT(widget), "prop_type"));
 	value = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
-	
+
 	/* FIXME: the first toggle button to be checked/dechecked does not work, but after that everything is cool.  what gives? */
 	g_settings_set_int (ma->settings, (gchar *)name, value);
 	g_settings_set_int (ma->settings, (gchar *)name, value);
-	
+
 	switch(prop_type)
 	{
 		case PROP_SPEED:
@@ -161,7 +161,7 @@ spin_button_changed_cb(GtkWidget *widget, gpointer name)
 				if (ma->graphs[i]->visible)
 					load_graph_start(ma->graphs[i]);
 			}
-			
+
 			break;
 		}
 		case PROP_SIZE:
@@ -169,25 +169,25 @@ spin_button_changed_cb(GtkWidget *widget, gpointer name)
 			for (i = 0; i < NGRAPHS; i++)
 			{
 				ma->graphs[i]->size = value ;
-				
+
 				if (ma->graphs[i]->orient)
 					gtk_widget_set_size_request (
-						ma->graphs[i]->main_widget, 
-						ma->graphs[i]->pixel_size, 
+						ma->graphs[i]->main_widget,
+						ma->graphs[i]->pixel_size,
 						ma->graphs[i]->size);
 			    else
 					gtk_widget_set_size_request (
-						ma->graphs[i]->main_widget, 
-						ma->graphs[i]->size, 
+						ma->graphs[i]->main_widget,
+						ma->graphs[i]->size,
 						ma->graphs[i]->pixel_size);
 			}
-			
+
 			break;
 		}
 		default:
 			g_assert_not_reached();
 	}
-	
+
 	return;
 }
 
@@ -197,14 +197,14 @@ add_page(GtkWidget *notebook, gchar *label)
 {
 	GtkWidget *page;
 	GtkWidget *page_label;
-	
+
 	page = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_set_homogeneous (GTK_BOX (page), TRUE);
 	page_label = gtk_label_new(label);
 	gtk_container_set_border_width(GTK_CONTAINER(page), 6);
-		
+
 	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), page, page_label);
-	
+
 	return page;
 }
 
@@ -254,23 +254,23 @@ add_color_selector(GtkWidget *page, gchar *name, gchar *key, MultiloadApplet *ma
 	GtkWidget *color_picker;
 	GdkRGBA color;
 	gchar *color_string;
-	
+
 	color_string = g_settings_get_string (ma->settings, key);
 	if (!color_string)
 		color_string = g_strdup ("#000000");
 	gdk_rgba_parse (&color, color_string);
 	g_free (color_string);
-		
+
 	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	label = gtk_label_new_with_mnemonic(name);
 	color_picker = gtk_color_button_new();
 	gtk_label_set_mnemonic_widget (GTK_LABEL (label), color_picker);
-	
+
 	gtk_box_pack_start(GTK_BOX(vbox), color_picker, FALSE, FALSE, 0);
 	gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
-	
-	gtk_box_pack_start(GTK_BOX(page), vbox, FALSE, FALSE, 0);	
-	
+
+	gtk_box_pack_start(GTK_BOX(page), vbox, FALSE, FALSE, 0);
+
 	g_object_set_data (G_OBJECT (color_picker), "MultiloadApplet", ma);
 
 	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(color_picker), &color);
@@ -279,7 +279,7 @@ add_color_selector(GtkWidget *page, gchar *name, gchar *key, MultiloadApplet *ma
 
 	if ( ! g_settings_is_writable (ma->settings, key))
 		hard_set_sensitive (vbox, FALSE);
-	
+
 	return;
 }
 
@@ -306,7 +306,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 5);
 	gtk_widget_show (vbox);
-	
+
 	gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), vbox,
 			    TRUE, TRUE, 0);
 
@@ -317,7 +317,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	category_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (categories_vbox), category_vbox, TRUE, TRUE, 0);
 	gtk_widget_show (category_vbox);
-	
+
 	title = g_strconcat ("<span weight=\"bold\">", _("Monitored Resources"), "</span>", NULL);
 	label = gtk_label_new_with_mnemonic (_(title));
 	gtk_label_set_use_markup (GTK_LABEL (label), TRUE);
@@ -329,24 +329,24 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 #endif
 	gtk_box_pack_start (GTK_BOX (category_vbox), label, FALSE, FALSE, 0);
 	g_free (title);
-	
+
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (category_vbox), hbox, TRUE, TRUE, 0);
 	gtk_widget_show (hbox);
-	
+
 	indent = gtk_label_new (HIG_IDENTATION);
 	gtk_label_set_justify (GTK_LABEL (indent), GTK_JUSTIFY_LEFT);
 	gtk_box_pack_start (GTK_BOX (hbox), indent, FALSE, FALSE, 0);
 	gtk_widget_show (indent);
-	
+
 	control_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (hbox), control_vbox, TRUE, TRUE, 0);
 	gtk_widget_show (control_vbox);
-	
+
 	control_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
 	gtk_box_pack_start (GTK_BOX (control_vbox), control_hbox, TRUE, TRUE, 0);
 	gtk_widget_show (control_hbox);
-	
+
 	check_box = gtk_check_button_new_with_mnemonic(_("_Processor"));
 	ma->check_boxes[0] = check_box;
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_box),
@@ -359,7 +359,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 
 	if ( ! g_settings_is_writable (ma->settings, "view-cpuload"))
 		hard_set_sensitive (check_box, FALSE);
-	
+
 	check_box = gtk_check_button_new_with_mnemonic(_("_Memory"));
 	ma->check_boxes[1] = check_box;
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_box),
@@ -372,7 +372,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 
 	if ( ! g_settings_is_writable (ma->settings, "view-memload"))
 		hard_set_sensitive (check_box, FALSE);
-	
+
 	check_box = gtk_check_button_new_with_mnemonic(_("_Network"));
 	ma->check_boxes[2] = check_box;
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_box),
@@ -400,7 +400,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 		hard_set_sensitive (check_box, FALSE);
 
 	check_box = gtk_check_button_new_with_mnemonic(_("_Load"));
-	ma->check_boxes[4] = check_box;	
+	ma->check_boxes[4] = check_box;
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check_box),
 				g_settings_get_boolean (ma->settings, "view-loadavg"));
 	g_object_set_data(G_OBJECT(check_box), "MultiloadApplet", ma);
@@ -439,7 +439,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	gtk_box_pack_start (GTK_BOX (category_vbox), label, FALSE, FALSE, 0);
 	gtk_widget_show (label);
 	g_free (title);
-	
+
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (category_vbox), hbox, TRUE, TRUE, 0);
 	gtk_widget_show (hbox);
@@ -452,19 +452,19 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	control_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (hbox), control_vbox, TRUE, TRUE, 0);
 	gtk_widget_show (control_vbox);
-	
+
 	control_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
 	gtk_box_pack_start (GTK_BOX (control_vbox), control_hbox, TRUE, TRUE, 0);
 	gtk_widget_show (control_hbox);
-	
+
 	label_size = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
-	
+
 	orient = mate_panel_applet_get_orient(ma->applet);
 	if ( (orient == MATE_PANEL_APPLET_ORIENT_UP) || (orient == MATE_PANEL_APPLET_ORIENT_DOWN) )
 		label_text = g_strdup(_("System m_onitor width: "));
 	else
 		label_text = g_strdup(_("System m_onitor height: "));
-	
+
 	label = gtk_label_new_with_mnemonic(label_text);
 #if GTK_CHECK_VERSION (3, 16, 0)
 	gtk_label_set_xalign (GTK_LABEL (label), 0.0f);
@@ -473,13 +473,13 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 #endif
 	gtk_size_group_add_widget (label_size, label);
         gtk_box_pack_start (GTK_BOX (control_hbox), label, FALSE, FALSE, 0);
-	
+
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_box_pack_start (GTK_BOX (control_hbox), hbox, TRUE, TRUE, 0);
 	gtk_widget_show (hbox);
 
 	spin_size = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
-			  
+
 	spin_button = gtk_spin_button_new_with_range(10, 1000, 5);
 	gtk_label_set_mnemonic_widget (GTK_LABEL (label), spin_button);
 	g_object_set_data(G_OBJECT(spin_button), "MultiloadApplet", ma);
@@ -489,7 +489,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 				(gdouble)g_settings_get_int(ma->settings, "size"));
 	g_signal_connect(G_OBJECT(spin_button), "value_changed",
 				G_CALLBACK(spin_button_changed_cb), "size");
-	
+
 	if ( ! g_settings_is_writable (ma->settings, "size")) {
 		hard_set_sensitive (label, FALSE);
 		hard_set_sensitive (hbox, FALSE);
@@ -497,7 +497,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 
 	gtk_size_group_add_widget (spin_size, spin_button);
 	gtk_box_pack_start (GTK_BOX (hbox), spin_button, FALSE, FALSE, 0);
-	
+
 	label = gtk_label_new (_("pixels"));
 #if GTK_CHECK_VERSION (3, 16, 0)
 	gtk_label_set_xalign (GTK_LABEL (label), 0.0f);
@@ -505,11 +505,11 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0f, 0.5f);
 #endif
 	gtk_box_pack_start (GTK_BOX (hbox), label, FALSE, FALSE, 0);
-	
+
 	control_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
 	gtk_box_pack_start (GTK_BOX (control_vbox), control_hbox, TRUE, TRUE, 0);
 	gtk_widget_show (control_hbox);
-	
+
 	label = gtk_label_new_with_mnemonic(_("Sys_tem monitor update interval: "));
 #if GTK_CHECK_VERSION (3, 16, 0)
 	gtk_label_set_xalign (GTK_LABEL (label), 0.0f);
@@ -518,11 +518,11 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 #endif
 	gtk_size_group_add_widget (label_size, label);
 	gtk_box_pack_start (GTK_BOX (control_hbox), label, FALSE, FALSE, 0);
-	
+
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_box_pack_start (GTK_BOX (control_hbox), hbox, TRUE, TRUE, 0);
 	gtk_widget_show (hbox);
-	
+
 	spin_button = gtk_spin_button_new_with_range(50, 10000, 50);
 	gtk_label_set_mnemonic_widget (GTK_LABEL (label), spin_button);
 	g_object_set_data(G_OBJECT(spin_button), "MultiloadApplet", ma);
@@ -539,7 +539,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 		hard_set_sensitive (label, FALSE);
 		hard_set_sensitive (hbox, FALSE);
 	}
-	
+
 	label = gtk_label_new(_("milliseconds"));
 #if GTK_CHECK_VERSION (3, 16, 0)
 	gtk_label_set_xalign (GTK_LABEL (label), 0.0f);
@@ -547,10 +547,10 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0f, 0.5f);
 #endif
 	gtk_box_pack_start (GTK_BOX (hbox), label, FALSE, FALSE, 0);
-	
+
 	g_free(label_text);
-	
-	
+
+
 	category_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (categories_vbox), category_vbox, TRUE, TRUE, 0);
 	gtk_widget_show (category_vbox);
@@ -567,7 +567,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	gtk_box_pack_start (GTK_BOX (category_vbox), label, FALSE, FALSE, 0);
 	gtk_widget_show (label);
 	g_free (title);
-	
+
 	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (category_vbox), hbox, TRUE, TRUE, 0);
 	gtk_widget_show (hbox);
@@ -583,7 +583,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 
 	ma->notebook = gtk_notebook_new();
 	gtk_container_add (GTK_CONTAINER (control_vbox), ma->notebook);
-	
+
 	page = add_page(ma->notebook,  _("Processor"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector(page, _("_User"), "cpuload-color0", ma);
@@ -591,7 +591,7 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	add_color_selector(page, _("N_ice"), "cpuload-color2", ma);
 	add_color_selector(page, _("I_OWait"), "cpuload-color3", ma);
 	add_color_selector(page, _("I_dle"), "cpuload-color4", ma);
-	
+
 	page = add_page(ma->notebook,  _("Memory"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector(page, _("_User"), "memload-color0", ma);
@@ -599,30 +599,31 @@ fill_properties(GtkWidget *dialog, MultiloadApplet *ma)
 	add_color_selector(page, _("_Buffers"), "memload-color2", ma);
 	add_color_selector (page, _("Cach_ed"), "memload-color3", ma);
 	add_color_selector(page, _("F_ree"), "memload-color4", ma);
-	
+
 	page = add_page(ma->notebook,  _("Network"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector (page, _("_In"), "netload2-color0", ma);
 	add_color_selector(page, _("_Out"), "netload2-color1", ma);
 	add_color_selector (page, _("_Local"), "netload2-color2", ma);
 	add_color_selector(page, _("_Background"), "netload2-color3", ma);
-	
+
 	page = add_page(ma->notebook,  _("Swap Space"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector(page, _("_Used"), "swapload-color0", ma);
 	add_color_selector(page, _("_Free"), "swapload-color1", ma);
-	
+
 	page = add_page(ma->notebook,  _("Load"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector(page, _("_Average"), "loadavg-color0", ma);
 	add_color_selector(page, _("_Background"), "loadavg-color1", ma);
+  add_color_selector(page, _("_Gridline"), "loadavg-color2", ma);
 
 	page = add_page (ma->notebook, _("Harddisk"));
 	gtk_container_set_border_width (GTK_CONTAINER (page), 12);
 	add_color_selector (page, _("_Read"), "diskload-color0", ma);
 	add_color_selector (page, _("_Write"), "diskload-color1", ma);
 	add_color_selector (page, _("_Background"), "diskload-color2", ma);
-	
+
 	return;
 }
 
@@ -644,7 +645,7 @@ multiload_properties_cb (GtkAction       *action,
 		gtk_window_present (GTK_WINDOW (dialog));
 		return;
 	}
-	
+
 	dialog = gtk_dialog_new_with_buttons (_("System Monitor Preferences"),
 					      NULL, 0,
 					   GTK_STOCK_HELP, GTK_RESPONSE_HELP,
@@ -660,7 +661,7 @@ multiload_properties_cb (GtkAction       *action,
 	fill_properties(dialog, ma);
 
 	properties_set_insensitive(ma);
-	
+
 	g_signal_connect(G_OBJECT(dialog), "response",
 			 G_CALLBACK(properties_close_cb), ma);
 


### PR DESCRIPTION
Load graph is scaled automatically according to average load value, like old time xsysload program. If Load  grows over 1, there will be a line signalizing load is over 1 and whole graph is scaled accordingly. When Load goes over 2, there will be two lines etc. Similarly when Load goes down,grid lines will be removed.
Color of grid line can be set in properties. Schema was updated to keep the value of grid line color.

Notes for reviewer:
Most of diff is trailing blanks or whitespaces in empty lines which were automatically changed by atom editor.
Real heavy changes are in load-graph.c in function load_graph_draw()