### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -1203,12 +1203,22 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# gnomepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for gnome-applets.
+# Copyright © 1998-2010 the gnome-applets authors.
+# This file is distributed under the same license as the gnome-applets package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 1998-2003.
+# Kuba Winnicki <bw@idc.com.pl>, 1999.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2006.
+# Paweł Marciniak <pmarciniak@lodz.home.pl>, 2006.
+# Zbigniew Braniecki <gandalf@aviary.pl>, 2007.
+# Stanisław Małolepszy <smalolepszy@aviary.pl>, 2007.
+# Julian Sikorski <belegdol@gmail.com>, 2008.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Joanna Mazgaj <jmazgaj@aviary.pl>, 2009.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.