### PR TITLE
If the list is empty, it will show media-floppy icon

### DIFF
--- a/drivemount/drive-list.c
+++ b/drivemount/drive-list.c
@@ -65,7 +65,7 @@ static void add_mount          (DriveList *self,
 				GMount *mount);
 static void remove_mount       (DriveList *self,
 				GMount *mount);
-
+static void queue_relayout     (DriveList *self);
 static void
 drive_list_class_init (DriveListClass *class)
 {
@@ -92,8 +92,9 @@ drive_list_init (DriveList *self)
 
     /* listen for drive connects/disconnects, and add
      * currently connected drives. */
-    if (!volume_monitor)
-	volume_monitor = g_volume_monitor_get ();
+	self->count = 0;
+	if (!volume_monitor)
+		volume_monitor = g_volume_monitor_get ();
 
     g_signal_connect_object (volume_monitor, "mount_added",
 			     G_CALLBACK (mount_added), self, 0);
@@ -107,22 +108,34 @@ drive_list_init (DriveList *self)
 			     G_CALLBACK (volume_changed), self, 0);
     g_signal_connect_object (volume_monitor, "volume_removed",
 			     G_CALLBACK (volume_removed), self, 0);
-    volumes = g_volume_monitor_get_volumes (volume_monitor);
-    for (tmp = volumes; tmp != NULL; tmp = tmp->next) {
-	GVolume *volume = tmp->data;
+	volumes = g_volume_monitor_get_volumes (volume_monitor);
+	for (tmp = volumes; tmp != NULL; tmp = tmp->next)
+	{
+			GVolume *volume = tmp->data;
+			add_volume (self, volume);
+			g_object_unref (volume);
+			self->count++;
+	}
+	g_list_free (volumes);
 
-	add_volume (self, volume);
-	g_object_unref (volume);
-    }
-    g_list_free (volumes);
+	mounts = g_volume_monitor_get_mounts (volume_monitor);
+	for (tmp = mounts; tmp != NULL; tmp = tmp->next)
+	{
+			GMount *mount = tmp->data;
+			add_mount (self, mount);
+			g_object_unref (mount);
+			self->count++;
+	}
+	self->dummy = drive_button_new (NULL);
+	gtk_button_set_relief (GTK_BUTTON (self->dummy), self->relief);
+	drive_button_set_size (DRIVE_BUTTON (self->dummy), self->icon_size);
 
-    mounts = g_volume_monitor_get_mounts (volume_monitor);
-    for (tmp = mounts; tmp != NULL; tmp = tmp->next) {
-	GMount *mount = tmp->data;
-
-	add_mount (self, mount);
-	g_object_unref (mount);
-    }
+	if (self->count == 0)
+	{
+		gtk_container_add (GTK_CONTAINER (self), self->dummy);
+		queue_relayout (self);
+		drive_button_queue_update (self->dummy);
+	}
     g_list_free (mounts);
 }
 
@@ -163,7 +176,7 @@ drive_list_dispose (GObject *object)
 					  G_CALLBACK (volume_removed), self);
 
     if (self->layout_tag)
-	g_source_remove (self->layout_tag);
+			g_source_remove (self->layout_tag);
     self->layout_tag = 0;
 
     if (G_OBJECT_CLASS (drive_list_parent_class)->dispose)
@@ -225,33 +238,56 @@ list_buttons (gpointer key, gpointer value, gpointer user_data)
 static gboolean
 relayout_buttons (gpointer data)
 {
-    DriveList *self = DRIVE_LIST (data);
-    GList *sorted_buttons = NULL, *tmp;
-    int i;
+	DriveList *self = DRIVE_LIST (data);
+	GList *sorted_buttons = NULL, *tmp;
+	int i;
 
 
-    self->layout_tag = 0;
-    g_hash_table_foreach (self->volumes, list_buttons, &sorted_buttons);
-    g_hash_table_foreach (self->mounts, list_buttons, &sorted_buttons);
+	self->layout_tag = 0;
+ 	if ( self->count > 0 )
+	{
+		g_hash_table_foreach (self->volumes, list_buttons, &sorted_buttons);
+		g_hash_table_foreach (self->mounts, list_buttons, &sorted_buttons);
 
-    /* position buttons in the table according to their sorted order */
-    for (tmp = sorted_buttons, i = 0; tmp != NULL; tmp = tmp->next, i++) {
-	GtkWidget *button = tmp->data;
-    
-	if (self->orientation == GTK_ORIENTATION_HORIZONTAL) {
-	    gtk_container_child_set (GTK_CONTAINER (self), button,
-				     "left-attach", i + 1, "top-attach", 0,
-				     "width", 1, "height", 1,
-				     NULL);
-	} else {
-	    gtk_container_child_set (GTK_CONTAINER (self), button,
-				     "left-attach", 0, "top-attach", i + 1,
-				     "width", 1, "height", 1,
-				     NULL);
+		/* position buttons in the table according to their sorted order */
+		for (tmp = sorted_buttons, i = 0; tmp != NULL; tmp = tmp->next, i++)
+		{
+			GtkWidget *button = tmp->data;
+
+			if (self->orientation == GTK_ORIENTATION_HORIZONTAL) {
+				gtk_container_child_set (GTK_CONTAINER (self), button,
+										"left-attach", i + 1, "top-attach", 0,
+										"width", 1, "height", 1,
+										NULL);
+			}
+			else
+			{
+				gtk_container_child_set (GTK_CONTAINER (self), button,
+										"left-attach", 0, "top-attach", i + 1,
+										"width", 1, "height", 1,
+										NULL);
+			}
+		}
 	}
-    }
-
-    return FALSE;
+	else
+	{
+		gtk_widget_show (self->dummy);
+		if (self->orientation == GTK_ORIENTATION_HORIZONTAL)
+		{
+			gtk_container_child_set (GTK_CONTAINER (self), self->dummy,
+									"left-attach", i + 1, "top-attach", 0,
+									"width", 1, "height", 1,
+									NULL);
+		}
+		else
+		{
+			gtk_container_child_set (GTK_CONTAINER (self), self->dummy,
+									"left-attach", 0, "top-attach", i + 1,
+									"width", 1, "height", 1,
+									NULL);
+    	}
+	}
+	return FALSE;
 }
 
 static void
@@ -268,7 +304,9 @@ mount_added (GVolumeMonitor *monitor,
 	     DriveList *self)
 {
     add_mount (self, mount);
-
+		self->count++;
+		if (self->count == 1)
+			gtk_container_remove (GTK_CONTAINER (self), g_object_ref(self->dummy));
     mount_changed (monitor, mount, self);
 }
 
@@ -297,8 +335,12 @@ mount_removed (GVolumeMonitor *monitor,
 	       DriveList *self)
 {
     remove_mount (self, mount);
-
     mount_changed (monitor, mount, self);
+		self->count--;
+		if (self->count == 0) {
+			gtk_container_add (GTK_CONTAINER (self), self->dummy);
+			queue_relayout(self);
+		}
 }
 
 static void
@@ -307,6 +349,9 @@ volume_added (GVolumeMonitor *monitor,
 	      DriveList *self)
 {
     add_volume (self, volume);
+		self->count++;
+		if (self->count == 1)
+			gtk_container_remove (GTK_CONTAINER (self), g_object_ref(self->dummy));
 }
 
 static void
@@ -327,6 +372,11 @@ volume_removed (GVolumeMonitor *monitor,
 		DriveList *self)
 {
     remove_volume (self, volume);
+		self->count--;
+		if (self->count == 0) {
+			gtk_container_add (GTK_CONTAINER (self), self->dummy);
+			queue_relayout(self);
+		}
 }
 
 static void
@@ -449,7 +499,7 @@ void
 drive_list_set_transparent (DriveList *self, gboolean transparent)
 {
     GtkReliefStyle relief;
-   
+
     relief  = transparent ? GTK_RELIEF_NONE : GTK_RELIEF_NORMAL;
 
     if (relief == self->relief)

--- a/drivemount/drive-list.h
+++ b/drivemount/drive-list.h
@@ -46,6 +46,8 @@ struct _DriveList
     GtkOrientation orientation;
     guint layout_tag;
     GtkReliefStyle relief;
+    GtkWidget *dummy;
+    gint count;
 
     int icon_size;
 };


### PR DESCRIPTION
When the applet is added and there are no external mounts defined in gstab, no media inserted, the applet is not visible becasue it has nothing to show. This change will add a dummy unclickable icon. When some USB is connected or fstab chanegd, it will remove the dummy icon and behave as before. If there is again niothing to show in applet, dummy icon will be shown.
This addresses issue #251.