### PR TITLE
avoid deprecated gdk_screen_get_width/height and gdk_screen_width/height

### DIFF
--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -335,30 +335,32 @@ get_menu_pos (GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer data)
 	gint tempx, tempy, width, height;
 	gint screen_width, screen_height;
 
-        gtk_widget_get_preferred_size (GTK_WIDGET (menu), NULL, &reqmenu);
+	gtk_widget_get_preferred_size (GTK_WIDGET (menu), NULL, &reqmenu);
 	gdk_window_get_origin (GDK_WINDOW (gtk_widget_get_window(curr_data->applet)), &tempx, &tempy);
 	gdk_window_get_geometry (GDK_WINDOW (gtk_widget_get_window(curr_data->applet)), NULL, NULL,
 				 &width, &height
 				 );
      			      
-     	switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (curr_data->applet))) {
-     	case MATE_PANEL_APPLET_ORIENT_DOWN:
-        	tempy += height;
-     		break;
-     	case MATE_PANEL_APPLET_ORIENT_UP:
-        	tempy -= reqmenu.height;
-     		break;
-     	case MATE_PANEL_APPLET_ORIENT_LEFT:
-     		tempx -= reqmenu.width;
+	switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (curr_data->applet))) {
+	case MATE_PANEL_APPLET_ORIENT_DOWN:
+		tempy += height;
 		break;
-     	case MATE_PANEL_APPLET_ORIENT_RIGHT:
-     		tempx += width;
+	case MATE_PANEL_APPLET_ORIENT_UP:
+		tempy -= reqmenu.height;
 		break;
-     	}
-	screen_width = gdk_screen_width ();
-     	screen_height = gdk_screen_height ();
-     	*x = CLAMP (tempx, 0, MAX (0, screen_width - reqmenu.width));
-     	*y = CLAMP (tempy, 0, MAX (0, screen_height - reqmenu.height));
+	case MATE_PANEL_APPLET_ORIENT_LEFT:
+		tempx -= reqmenu.width;
+		break;
+	case MATE_PANEL_APPLET_ORIENT_RIGHT:
+		tempx += width;
+		break;
+	}
+
+	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
+				 NULL, NULL, &screen_width, &screen_height);
+
+	*x = CLAMP (tempx, 0, MAX (0, screen_width - reqmenu.width));
+	*y = CLAMP (tempy, 0, MAX (0, screen_height - reqmenu.height));
 }
 
 static void

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -414,6 +414,8 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
         GtkAllocation   allocation;
         gint            menu_xpos;
         gint            menu_ypos;
+        gint            sc_width;
+        gint            sc_height;
 
         widget = GTK_WIDGET (gdata);
 
@@ -421,7 +423,10 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
 
         gdk_window_get_origin (gtk_widget_get_window (widget), &menu_xpos, &menu_ypos);
 
-	gtk_widget_get_allocation (widget, &allocation);
+        gtk_widget_get_allocation (widget, &allocation);
+
+        gdk_window_get_geometry (gdk_screen_get_root_window (gtk_widget_get_screen (widget)), NULL, NULL,
+                                 &sc_width, &sc_height);
 
         menu_xpos += allocation.x;
         menu_ypos += allocation.y;
@@ -429,14 +434,14 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
         switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (widget))) {
         case MATE_PANEL_APPLET_ORIENT_DOWN:
         case MATE_PANEL_APPLET_ORIENT_UP:
-                if (menu_ypos > gdk_screen_get_height (gtk_widget_get_screen (widget)) / 2)
+                if (menu_ypos > sc_height / 2)
                         menu_ypos -= requisition.height;
                 else
                         menu_ypos += allocation.height;
                 break;
         case MATE_PANEL_APPLET_ORIENT_RIGHT:
         case MATE_PANEL_APPLET_ORIENT_LEFT:
-                if (menu_xpos > gdk_screen_get_width (gtk_widget_get_screen (widget)) / 2)
+                if (menu_xpos > sc_width / 2)
                         menu_xpos -= requisition.width;
                 else
                         menu_xpos += allocation.width;

--- a/stickynotes/stickynotes_applet.c
+++ b/stickynotes/stickynotes_applet.c
@@ -154,6 +154,8 @@ stickynotes_destroy (GtkWidget *widget,
 void
 stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
 {
+	gint sc_height;
+
 	stickynotes = g_new(StickyNotes, 1);
 
 	stickynotes->notes = NULL;
@@ -189,7 +191,10 @@ stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
 	                  G_CALLBACK (preferences_apply_cb), NULL);
 
 	/* Max height for large notes*/
-	stickynotes->max_height = 0.8*gdk_screen_get_height( gdk_screen_get_default() );
+	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()), NULL, NULL,
+				 NULL, &sc_height);
+
+	stickynotes->max_height = 0.8 * sc_height;
 
 	/* Load sticky notes */
 	stickynotes_load (gtk_widget_get_screen (GTK_WIDGET (mate_panel_applet)));


### PR DESCRIPTION
avoid deprecated:

- gdk_screen_get_width/height

- gdk_screen_width/height

