### PR TITLE
gtk 3.22: avoid deprecated gdk_screen_get_monitor... functions:

### DIFF
--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -176,6 +176,25 @@ drive_button_unrealize (GtkWidget *widget)
 }
 #endif /* 0 */
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+static int
+_gtk_get_monitor_num (GdkMonitor *monitor)
+{
+    GdkDisplay *display;
+    int n_monitors, i;
+
+    display = gdk_monitor_get_display(monitor);
+    n_monitors = gdk_display_get_n_monitors(display);
+
+    for(i = 0; i < n_monitors; i++)
+    {
+        if(gdk_display_get_monitor(display, i) == monitor) return i;
+    }
+
+    return -1;
+}
+#endif
+
 /* the following function is adapted from gtkmenuitem.c */
 static void
 position_menu (GtkMenu *menu, gint *x, gint *y,
@@ -188,7 +207,12 @@ position_menu (GtkMenu *menu, gint *x, gint *y,
     GtkRequisition requisition;
     GtkTextDirection direction;
     GdkRectangle monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+    GdkMonitor *monitor_num;
+    GdkDisplay *display;
+#else
     gint monitor_num;
+#endif
 
     g_return_if_fail (menu != NULL);
     g_return_if_fail (x != NULL);
@@ -203,9 +227,17 @@ position_menu (GtkMenu *menu, gint *x, gint *y,
     theight = requisition.height;
 
     screen = gtk_widget_get_screen (GTK_WIDGET (menu));
+#if GTK_CHECK_VERSION (3, 22, 0)
+    display =gdk_screen_get_display (screen);
+    monitor_num = gdk_display_get_monitor_at_window (display, gtk_widget_get_window (widget));
+    if (monitor_num == NULL)
+        monitor_num = gdk_display_get_monitor (display, 0);
+    gdk_monitor_get_geometry (monitor_num, &monitor);
+#else
     monitor_num = gdk_screen_get_monitor_at_window (screen, gtk_widget_get_window (widget));
     if (monitor_num < 0) monitor_num = 0;
     gdk_screen_get_monitor_geometry (screen, monitor_num, &monitor);
+#endif
 
     if (!gdk_window_get_origin (gtk_widget_get_window (widget), &tx, &ty)) {
 	g_warning ("Menu not on screen");
@@ -230,7 +262,12 @@ position_menu (GtkMenu *menu, gint *x, gint *y,
 
     *x = CLAMP (tx, monitor.x, MAX (monitor.x, monitor.x + monitor.width - twidth));
     *y = ty;
+
+#if GTK_CHECK_VERSION (3, 22, 0)
+    gtk_menu_set_monitor (menu, _gtk_get_monitor_num (monitor_num));
+#else
     gtk_menu_set_monitor (menu, monitor_num);
+#endif
 }
 
 static gboolean

--- a/trashapplet/src/xstuff.c
+++ b/trashapplet/src/xstuff.c
@@ -150,10 +150,14 @@ draw_zoom_animation (GdkScreen *gscreen,
 void
 xstuff_zoom_animate (GtkWidget *widget, GdkRectangle *opt_rect)
 {
-	GdkScreen *gscreen;
-	GdkRectangle rect, dest;
+	GdkScreen    *gscreen;
+	GdkRectangle  rect, dest;
 	GtkAllocation allocation;
-	int monitor;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor   *monitor;
+#else
+	int           monitor;
+#endif
 
 	if (opt_rect)
 		rect = *opt_rect;
@@ -169,8 +173,14 @@ xstuff_zoom_animate (GtkWidget *widget, GdkRectangle *opt_rect)
 	}
 
 	gscreen = gtk_widget_get_screen (widget);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	monitor = gdk_display_get_monitor_at_window (gdk_screen_get_display (gscreen),
+						     gtk_widget_get_window (widget));
+	gdk_monitor_get_geometry (monitor, &dest);
+#else
 	monitor = gdk_screen_get_monitor_at_window (gscreen, gtk_widget_get_window (widget));
 	gdk_screen_get_monitor_geometry (gscreen, monitor, &dest);
+#endif
 
 	draw_zoom_animation (gscreen,
 			     rect.x, rect.y, rect.width, rect.height,


### PR DESCRIPTION
avoid deprecated:

gdk_screen_get_monitor_geometry
gdk_screen_get_monitor_at_window