### PR TITLE
GSettings change recognized dynamically

### DIFF
--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -544,6 +544,13 @@ drive_button_set_size (DriveButton *self, int icon_size)
     }
 }
 
+void
+drive_button_redraw (gpointer key, gpointer value, gpointer user_data)
+{
+    DriveButton *button = value;
+    drive_button_queue_update (button);
+}
+
 int
 drive_button_compare (DriveButton *button, DriveButton *other_button)
 {

--- a/drivemount/drive-button.h
+++ b/drivemount/drive-button.h
@@ -64,6 +64,7 @@ void       drive_button_set_size        (DriveButton *button,
 int        drive_button_compare         (DriveButton *button,
 					 DriveButton *other_button);
 GSettings  *settings;
+void       drive_button_redraw (gpointer key, gpointer value, gpointer user_data);
 
 G_END_DECLS
 

--- a/drivemount/drive-list.c
+++ b/drivemount/drive-list.c
@@ -486,6 +486,20 @@ drive_list_set_panel_size (DriveList *self, int panel_size)
     }
 }
 
+void
+drive_list_redraw (DriveList *self)
+{
+    g_hash_table_foreach (self->volumes, drive_button_redraw, self);
+    g_hash_table_foreach (self->mounts, drive_button_redraw, self);
+}
+
+void
+settings_color_changed (GSettings *settings, gchar *key, DriveList *drive_list)
+{
+    g_return_if_fail (DRIVE_IS_LIST (drive_list));
+    drive_list_redraw (drive_list);
+}
+
 static void
 set_button_relief (gpointer key, gpointer value, gpointer user_data)
 {

--- a/drivemount/drive-list.h
+++ b/drivemount/drive-list.h
@@ -66,5 +66,7 @@ void       drive_list_set_panel_size  (DriveList *list,
 void       drive_list_set_transparent (DriveList *self,
 				       gboolean transparent);
 GSettings *settings;
+void       drive_list_redraw (DriveList *self);
+void       settings_color_changed (GSettings *settings, gchar *key, DriveList *drive_list);
 
 #endif /* DRIVE_LIST_H */

--- a/drivemount/drivemount.c
+++ b/drivemount/drivemount.c
@@ -193,6 +193,10 @@ applet_factory (MatePanelApplet *applet,
 	settings = g_settings_new ( "org.mate.drivemount");
 
 	drive_list = drive_list_new ();
+    g_signal_connect(settings,
+                     "changed::drivemount-checkmark-color",
+                     G_CALLBACK (settings_color_changed),
+                     drive_list);
 	gtk_container_add (GTK_CONTAINER (applet), drive_list);
 
 	g_signal_connect_object (applet, "change_orient",


### PR DESCRIPTION
When color is changed in dconf-editor, it is immediately shown in applet, no need to remount.