### PR TITLE
stickynotes: fix text selection

### DIFF
--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -292,6 +292,9 @@ stickynote_new_aux (GdkScreen *screen, gint x, gint y, gint w, gint h)
 
 	g_object_unref(builder);
 
+	g_signal_connect_after (note->w_body, "button-press-event",
+	                        G_CALLBACK (gtk_true), note);
+
 	g_signal_connect (gtk_text_view_get_buffer(GTK_TEXT_VIEW(note->w_body)),
 			  "changed",
 			  G_CALLBACK (buffer_changed), note);


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-applets/issues/236

taken from:
https://git.gnome.org/browse/gnome-applets/commit/?id=e189ba213c0f8db876dd020d1d80b9f8b576dd75