### PR TITLE
Add >=cpupower-4.7 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -374,6 +374,8 @@ fi
 AM_CONDITIONAL(HAVE_LIBCPUFREQ, test x$have_libcpufreq = xyes)
 AC_SUBST(LIBCPUFREQ_LIBS)
 
+AC_CHECK_HEADERS([cpupower.h])
+
 build_cpufreq_applet=no
 
 if test x$disable_cpufreq = xno; then

--- a/cpufreq/src/cpufreq-monitor-libcpufreq.c
+++ b/cpufreq/src/cpufreq-monitor-libcpufreq.c
@@ -19,12 +19,16 @@
  * Authors : Carlos García Campos <carlosgc@gnome.org>
  */
 
+#include <config.h>
+
 #include <glib.h>
 #include <glib/gi18n.h>
 
 #include <stdlib.h>
-#include <linux/version.h>
 #include <cpufreq.h>
+#ifdef HAVE_CPUPOWER_H
+#include <cpupower.h>
+#endif
 #include "cpufreq-monitor-libcpufreq.h"
 #include "cpufreq-utils.h"
 
@@ -111,7 +115,7 @@ cpufreq_monitor_libcpufreq_run (CPUFreqMonitor *monitor)
 		/* Check whether it failed because
 		 * cpu is not online.
 		 */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+#ifndef HAVE_CPUPOWER_H
 		if (!cpufreq_cpu_exists (cpu)) {
 #else
 		if (cpupower_is_cpu_online (cpu)) {


### PR DESCRIPTION
Drops linux version detection as that relies on linux headers version,
not actual cpupower version (they may be independent, as with Gentoo)

Instead, detect presence of cpupower.h header file.

Starting with cpupower-4.9 in Gentoo, we are installing this header even
though it has not been resolved yet in upstream kernel's cpupower
installer.  Mike Gilbert (floppym@gentoo.org) has told me that he
intends to email the linux-pm mailing list about it in the near future.

This is probably the best solution, assuming that other distros have
this header installed (and eventually that upstream will)

Should resolve #238 and I think it is a better solution than #217