### PR TITLE
Bump Max Range

### DIFF
--- a/command/command.c
+++ b/command/command.c
@@ -164,7 +164,7 @@ command_settings_callback (GtkAction *action, CommandApplet *command_applet)
 #endif
     gtk_grid_attach (grid, widget, 1, 1, 1, 1);
 
-    interval = gtk_spin_button_new_with_range (1.0, 600.0, 1.0);
+    interval = gtk_spin_button_new_with_range (1.0, 86400.0, 1.0);
     gtk_grid_attach (grid, interval, 2, 1, 1, 1);
 
     widget = gtk_label_new (_("Maximum width (chars):"));

--- a/command/command.c
+++ b/command/command.c
@@ -416,3 +416,4 @@ MATE_PANEL_APPLET_OUT_PROCESS_FACTORY("CommandAppletFactory",
                                       "Command applet",
                                       command_factory,
                                       NULL)
+    


### PR DESCRIPTION
Increase time range end point to allow command to occur inside a range for up to 86400 seconds (24 hours) in a second.