### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -2,6 +2,7 @@
  * accented (and other) characters to be pasted into other apps.
  */
 
+#include <gdk/gdkx.h>
 #include <config.h>
 #include <string.h>
 #include <mate-panel-applet.h>
@@ -355,10 +356,8 @@ get_menu_pos (GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer data)
 		tempx += width;
 		break;
 	}
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()),
-				 NULL, NULL, &screen_width, &screen_height);
-
+	screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()));
+	screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()));
 	*x = CLAMP (tempx, 0, MAX (0, screen_width - reqmenu.width));
 	*y = CLAMP (tempy, 0, MAX (0, screen_height - reqmenu.height));
 }

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -24,6 +24,7 @@
 #endif
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <gio/gio.h>
 #include <mate-panel-applet.h>
@@ -415,8 +416,6 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
         GtkAllocation   allocation;
         gint            menu_xpos;
         gint            menu_ypos;
-        gint            sc_width;
-        gint            sc_height;
 
         widget = GTK_WIDGET (gdata);
 
@@ -426,23 +425,20 @@ cpufreq_applet_popup_position_menu (GtkMenu  *menu,
 
         gtk_widget_get_allocation (widget, &allocation);
 
-        gdk_window_get_geometry (gdk_screen_get_root_window (gtk_widget_get_screen (widget)), NULL, NULL,
-                                 &sc_width, &sc_height);
-
         menu_xpos += allocation.x;
         menu_ypos += allocation.y;
 
         switch (mate_panel_applet_get_orient (MATE_PANEL_APPLET (widget))) {
         case MATE_PANEL_APPLET_ORIENT_DOWN:
         case MATE_PANEL_APPLET_ORIENT_UP:
-                if (menu_ypos > sc_height / 2)
+                if (menu_ypos > HeightOfScreen (gdk_x11_screen_get_xscreen (gtk_widget_get_screen (widget))) / 2)
                         menu_ypos -= requisition.height;
                 else
                         menu_ypos += allocation.height;
                 break;
         case MATE_PANEL_APPLET_ORIENT_RIGHT:
         case MATE_PANEL_APPLET_ORIENT_LEFT:
-                if (menu_xpos > sc_width / 2)
+                if (menu_xpos > WidthOfScreen (gdk_x11_screen_get_xscreen (gtk_widget_get_screen (widget))) / 2)
                         menu_xpos -= requisition.width;
                 else
                         menu_xpos += allocation.width;

--- a/stickynotes/stickynotes_applet.c
+++ b/stickynotes/stickynotes_applet.c
@@ -24,6 +24,7 @@
 #include "stickynotes.h"
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 StickyNotes *stickynotes = NULL;
 
@@ -154,8 +155,6 @@ stickynotes_destroy (GtkWidget *widget,
 void
 stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
 {
-	gint sc_height;
-
 	stickynotes = g_new(StickyNotes, 1);
 
 	stickynotes->notes = NULL;
@@ -191,10 +190,7 @@ stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
 	                  G_CALLBACK (preferences_apply_cb), NULL);
 
 	/* Max height for large notes*/
-	gdk_window_get_geometry (gdk_screen_get_root_window (gdk_screen_get_default()), NULL, NULL,
-				 NULL, &sc_height);
-
-	stickynotes->max_height = 0.8 * sc_height;
+	stickynotes->max_height = 0.8 * HeightOfScreen (gdk_x11_screen_get_xscreen (gdk_screen_get_default ()));
 
 	/* Load sticky notes */
 	stickynotes_load (gtk_widget_get_screen (GTK_WIDGET (mate_panel_applet)));


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-applets/commit/d809e57c7b09f545f1cf847f514fa738d44ac2b3
https://github.com/mate-desktop/mate-applets/commit/2f5515815c1f6c9b66f85d6ec228aad7aea0b441

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height

gdk_screen_width
gdk_screen_height