### PR TITLE
Fix clock applet crashes

### DIFF
--- a/mateweather/main.c
+++ b/mateweather/main.c
@@ -35,9 +35,6 @@ static gboolean mateweather_applet_new(MatePanelApplet* applet, const gchar* iid
 
 	gw_applet->applet = applet;
 	gw_applet->mateweather_info = NULL;
-#ifdef HAVE_LIBNOTIFY
-	gw_applet->mateweather_previnfo = NULL;
-#endif
 	gw_applet->settings = mate_panel_applet_settings_new (applet, "org.mate.weather");
 
 	mateweather_applet_create(gw_applet);

--- a/mateweather/mateweather-applet.c
+++ b/mateweather/mateweather-applet.c
@@ -458,8 +458,7 @@ update_finish (WeatherInfo *info, gpointer data)
 	    place_widgets(gw_applet);
 
 #ifdef HAVE_LIBNOTIFY
-        if (gw_applet->mateweather_pref.show_notifications &&
-            !weather_info_equal(gw_applet->mateweather_previnfo, gw_applet->mateweather_info))
+        if (gw_applet->mateweather_pref.show_notifications)
         {
 		    NotifyNotification *n;
 	            
@@ -499,9 +498,6 @@ update_finish (WeatherInfo *info, gpointer data)
 		   	 g_free (detail);
 		    }
         }
-
-        weather_info_free (gw_applet->mateweather_previnfo);
-        gw_applet->mateweather_previnfo = weather_info_clone (gw_applet->mateweather_info);
 #endif
     }
     else
@@ -558,5 +554,4 @@ void mateweather_update (MateWeatherApplet *gw_applet)
 						    &prefs,
 						    update_finish, gw_applet);
     }
-
 }

--- a/mateweather/mateweather-applet.c
+++ b/mateweather/mateweather-applet.c
@@ -553,7 +553,6 @@ void mateweather_update (MateWeatherApplet *gw_applet)
 	weather_info_update(gw_applet->mateweather_info, &prefs,
 			    update_finish, gw_applet);
     } else {
-        weather_info_abort (gw_applet->mateweather_info);
         weather_info_free(gw_applet->mateweather_info);
         gw_applet->mateweather_info = weather_info_new(gw_applet->mateweather_pref.location,
 						    &prefs,

--- a/mateweather/mateweather.h
+++ b/mateweather/mateweather.h
@@ -27,9 +27,6 @@ G_BEGIN_DECLS
 typedef struct _MateWeatherApplet {
 	MatePanelApplet* applet;
 	WeatherInfo* mateweather_info;
-#ifdef HAVE_LIBNOTIFY
-	WeatherInfo* mateweather_previnfo;
-#endif
 
 	GSettings* settings;
 


### PR DESCRIPTION
Reverting the commits is more a quick and dirty, but i will do the same for fedora to avoid spam in my mailbox from users who files out a rhbz report.
Maybe someone find a real fix for clock-applet crashes with those commits.
So, i will leave that PR open.

Fixes https://github.com/mate-desktop/libmateweather/issues/51