### PR TITLE
Ensure CPU frequency label is always displayed if selected

### DIFF
--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -688,7 +688,13 @@ cpufreq_applet_update (CPUFreqApplet *applet, CPUFreqMonitor *monitor)
         unit_label = cpufreq_utils_get_frequency_unit (freq);
 
         if (applet->show_freq) {
-                gtk_label_set_text (GTK_LABEL (applet->label), freq_label);
+                /*Force the label to render if frequencies are not found right away*/
+                if (freq_label == NULL){
+                        gtk_label_set_text (GTK_LABEL (applet->label),"---");
+                }
+                else{
+                        gtk_label_set_text (GTK_LABEL (applet->label), freq_label);
+                }
                 /*Hold the largest size set by any jumping text */
                 gtk_widget_get_preferred_size (GTK_WIDGET (applet->label),&req, NULL);
                 gtk_widget_set_size_request (GTK_WIDGET (applet->label),req.width, req.height);


### PR DESCRIPTION
Fix https://github.com/mate-desktop/mate-applets/issues/175 by removing old GTK 2 leftovers that never worked right and using  gtk_widget_get_preferred_size and gtk_widget_get_preferred_width to so the same job.  Same coding used to set frequency label, unit label, and percentage label widths. This also finally gets rid of the maximum applet size that under so many conditions clipped labels and apparently was responsible for #175