### PR TITLE
weather: Use widget name in cssprovider to limit it to just this applet

### DIFF
--- a/mateweather/mateweather-dialog.c
+++ b/mateweather/mateweather-dialog.c
@@ -539,7 +539,7 @@ override_widget_font (GtkWidget            *widget,
     gtk_css_provider_load_from_data (provider, css, -1, NULL);
 
     if (!provider_added) {
-        gtk_style_context_add_provider_for_screen (gtk_widget_get_screen (widget),
+        gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(widget)),
                                                    GTK_STYLE_PROVIDER (provider),
                                                    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
         provider_added = TRUE;

--- a/mateweather/mateweather-dialog.c
+++ b/mateweather/mateweather-dialog.c
@@ -535,11 +535,12 @@ override_widget_font (GtkWidget            *widget,
 
     provider = gtk_css_provider_get_default ();
 
-    css = g_strdup_printf ("textview { %s %s %s %s }", family, weight, style, size);
+    gtk_widget_set_name(GTK_WIDGET(widget), "MateWeatherAppletTextView");
+    css = g_strdup_printf ("#MateWeatherAppletTextView { %s %s %s %s }", family, weight, style, size);
     gtk_css_provider_load_from_data (provider, css, -1, NULL);
 
     if (!provider_added) {
-        gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(widget)),
+        gtk_style_context_add_provider_for_screen (gtk_widget_get_screen (widget),
                                                    GTK_STYLE_PROVIDER (provider),
                                                    GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
         provider_added = TRUE;


### PR DESCRIPTION
Will be needed if this is ever ported to in-process. If all of mate-applets including stickynotes was ported to in-process (needed for wayland, GTK4, or any other environment w/o GtkPlug/GtkSocket/Xembed) the font applied here is applied to stickynotes too if the cssprovider is for screen, as in that case the "process" in which the provider is valid becomes the entire panel.