### PR TITLE
Silent output when building.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_PREREQ(2.59)
 
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz no-dist-gzip check-news])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_MACRO_DIR(m4)
 
 dnl ***************************************************************************


### PR DESCRIPTION
When run `make`, the output looks like this:
```
  GEN      ku_IQ/ku_IQ.mo
  GEN    ku_IQ/
  GEN      hy/hy.mo
  GEN    hy/
  GEN      en_CA/en_CA.mo
  GEN    en_CA/
  GEN      fy/fy.mo
  GEN    fy/
  GEN      kab/kab.mo
  GEN    kab/
```