### PR TITLE
Extend command applet with launcher functionality

### DIFF
--- a/command/org.mate.applets.CommandApplet.mate-panel-applet.in.in
+++ b/command/org.mate.applets.CommandApplet.mate-panel-applet.in.in
@@ -6,5 +6,5 @@ _Description=Command Factory
 
 [CommandApplet]
 _Name=Command
-_Description=Shows the output of a command
+_Description=Shows the output of a command and allows execution of a command on left click
 Icon=utilities-terminal

--- a/command/org.mate.panel.applet.command.gschema.xml.in
+++ b/command/org.mate.panel.applet.command.gschema.xml.in
@@ -5,6 +5,11 @@
       <summary>Command to execute</summary>
       <description>Command/script to execute to get the output</description>
     </key>
+    <key name="command-launcher" type="s">
+      <default>''</default>
+      <summary>Command to execute on left click</summary>
+      <description>Command/script to execute when applet is clicked</description>
+    </key>
     <key name="interval" type="i">
       <default>1</default>
       <summary>Interval for the command</summary>


### PR DESCRIPTION
I recently switched to use mate-panel on my i3wm setup and I'm super happy with it but one thing I was missing to make the experience complete was a script module which can be configured to read the output of a script and execute scripts when clicked on it. 

The command applet already had most functionality and I just added an additional text field to hold a secondary command that is executed when someone left-clicks on the applet.

I'm total newbie when it comes to gtk coding so I would really appreciate any kind of feedback and can understand if this is an edge case which may not make it into the main branch, but nevertheless I could see this feature useful for a lot of people who want a more customized experience.