### PR TITLE
enable Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ language: bash
 services:
   - docker
 
-# Trigger only on the travis branch
-# Remove the lines if every thing is ok.
-branches:
-  only:
-  - travis
-
 before_install:
   - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
   - chmod +x docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,147 @@
+# vim: set ts=2 sts=2 sw=2 expandtab :
+dist: xenial
+sudo: required
+language: bash
+services:
+  - docker
+
+# Trigger only on the travis branch
+# Remove the lines if every thing is ok.
+branches:
+  only:
+  - travis
+
+before_install:
+  - curl -Ls -o docker-build https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/docker-build
+  - chmod +x docker-build
+
+install:
+  - sudo apt-get install -y python3-pip python3-setuptools
+  - sudo pip3 install --upgrade pip
+  - sudo pip install PyGithub
+  - ./docker-build --name ${DISTRO} --config .travis.yml --install
+
+script:
+  - ./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools
+
+env:
+  - DISTRO="archlinux/base"
+  - DISTRO="debian:sid"
+  - DISTRO="fedora:29"
+  - DISTRO="ubuntu:18.10"
+
+##########################################################
+# THE FOLLOWING LINES IS USED BY docker-build
+##########################################################
+requires:
+  archlinux:
+    # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-applets
+    - gcc
+    - git
+    - gucharmap
+    - gtksourceview3
+    - intltool
+    - itstool
+    - libgtop
+    - libnotify
+    - make
+    - mate-common
+    - mate-panel
+    - polkit
+    - upower
+    - which
+    - wireless_tools
+    - yelp-tools
+
+  debian:
+    # Useful URL: https://github.com/mate-desktop/debian-packages
+    # Useful URL: https://salsa.debian.org/debian-mate-team/mate-applets
+    - git
+    - intltool
+    - libcpupower-dev
+    - libdbus-1-dev
+    - libdbus-glib-1-dev
+    - libglib2.0-dev
+    - libgtk-3-dev
+    - libgtksourceview-3.0-dev
+    - libgtop2-dev
+    - libgucharmap-2-90-dev
+    - libiw-dev
+    - libmate-panel-applet-dev
+    - libmateweather-dev
+    - libnotify-dev
+    - libpolkit-gobject-1-dev
+    - libupower-glib-dev
+    - libwnck-3-dev
+    - libx11-dev
+    - libxml2-dev
+    - make
+    - mate-common
+    - x11proto-kb-dev
+    - yelp-tools
+
+  fedora:
+    # Useful URL: https://src.fedoraproject.org/cgit/rpms/mate-applets.git
+    - gcc
+    - git
+    - gtksourceview3-devel
+    - gucharmap-devel
+    - kernel-tools-libs-devel
+    - libgtop2-devel
+    - libnotify-devel
+    - libmateweather-devel
+    - libwnck3-devel
+    - libxml2-devel
+    - libICE-devel
+    - libSM-devel
+    - make
+    - mate-common
+    - mate-settings-daemon-devel
+    - mate-notification-daemon
+    - mate-panel-devel
+    - polkit-devel
+    - redhat-rpm-config
+    - startup-notification-devel
+    - upower-devel
+    - wireless-tools-devel
+
+  ubuntu:
+    - git
+    - intltool
+    - libcpufreq-dev
+    - libdbus-1-dev
+    - libdbus-glib-1-dev
+    - libglib2.0-dev
+    - libgtk-3-dev
+    - libgtksourceview-3.0-dev
+    - libgtop2-dev
+    - libgucharmap-2-90-dev
+    - libiw-dev
+    - libmate-panel-applet-dev
+    - libmateweather-dev
+    - libnotify-dev
+    - libpolkit-gobject-1-dev
+    - libupower-glib-dev
+    - libwnck-3-dev
+    - libx11-dev
+    - libxml2-dev
+    - make
+    - mate-common
+    - x11proto-kb-dev
+    - yelp-tools
+    - linux-tools-generic
+
+variables:
+  - CFLAGS="-Wall -Werror=format-security"
+
+before_scripts:
+  - if [ ${DISTRO_NAME} == "debian" ];then
+  -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
+  -     bash ./debian.sh
+  - fi
+  - if [ ${DISTRO_NAME} == "ubuntu" ];then
+  -     ln -sf `ls /usr/lib/libcpupower.so.*|head -1` /usr/lib/libcpupower.so
+  - fi
+
+after_scripts:
+  - make distcheck


### PR DESCRIPTION
Currently building for debian and ubuntu is disabled.
Their builds failed with 
```
 CCLD     mate-cpufreq-selector
/usr/bin/ld: cannot find -lcpupower
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile:586: mate-cpufreq-selector] Error 1
make[5]: Leaving directory '/rootdir/cpufreq/src/cpufreq-selector'
make[4]: *** [Makefile:501: all] Error 2
make[4]: Leaving directory '/rootdir/cpufreq/src/cpufreq-selector'
make[3]: *** [Makefile:636: all-recursive] Error 1
make[3]: Leaving directory '/rootdir/cpufreq/src'
make[2]: *** [Makefile:594: all-recursive] Error 1
make[2]: Leaving directory '/rootdir/cpufreq'
make[1]: *** [Makefile:555: all-recursive] Error 1
make[1]: Leaving directory '/rootdir'
make: *** [Makefile:487: all] Error 2
!!! ERROR: run command [docker exec -t mate-applets-debian-build /rootdir/src_build].
The command "./docker-build --name ${DISTRO} --verbose --config .travis.yml --build autotools" exited with 1.
```
https://travis-ci.org/mate-desktop/mate-applets/builds/495656810
Well known cpupower vs. cpufreq problem.
And cpupower is part of kernel-tools package of some distros.
At debian-packages we use `--with-cpufreq-lib=cpufreq` as configure option.
https://github.com/mate-desktop/debian-packages/blob/master/mate-applets/debian/rules#L17
Maybe it is possible to add different build options to travis.yml for debian/ubuntu?
Or applying a patch?

Otherwise we can simply leave debian/ubuntu builds disable for travis.
It's really time that debian switch to kernel-tools packages like other distros.