### PR TITLE
Use g_list_free_full() convenience function

### DIFF
--- a/cpufreq/src/cpufreq-monitor.c
+++ b/cpufreq/src/cpufreq-monitor.c
@@ -175,18 +175,12 @@ cpufreq_monitor_finalize (GObject *object)
         }
 
         if (monitor->priv->available_freqs) {
-                g_list_foreach (monitor->priv->available_freqs,
-                                (GFunc) g_free,
-                                NULL);
-                g_list_free (monitor->priv->available_freqs);
+                g_list_free_full (monitor->priv->available_freqs, g_free);
                 monitor->priv->available_freqs = NULL;
         }
 
         if (monitor->priv->available_govs) {
-                g_list_foreach (monitor->priv->available_govs,
-                                (GFunc) g_free,
-                                NULL);
-                g_list_free (monitor->priv->available_govs);
+                g_list_free_full (monitor->priv->available_govs, g_free);
                 monitor->priv->available_govs = NULL;
         }
 

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
@@ -78,18 +78,12 @@ cpufreq_selector_sysfs_finalize (GObject *object)
         CPUFreqSelectorSysfs *selector = CPUFREQ_SELECTOR_SYSFS (object);
 
         if (selector->priv->available_freqs) {
-                g_list_foreach (selector->priv->available_freqs,
-                                (GFunc) g_free,
-				NULL);
-                g_list_free (selector->priv->available_freqs);
+                g_list_free_full (selector->priv->available_freqs, g_free);
                 selector->priv->available_freqs = NULL;
 	}
-           
+
         if (selector->priv->available_govs) {
-                g_list_foreach (selector->priv->available_govs,
-                                (GFunc) g_free,
-				NULL);
-                g_list_free (selector->priv->available_govs);
+                g_list_free_full (selector->priv->available_govs, g_free);
                 selector->priv->available_govs = NULL;
 	}
 

--- a/netspeed/src/backend.c
+++ b/netspeed/src/backend.c
@@ -122,8 +122,7 @@ get_default_route(void)
 void
 free_devices_list(GList *list)
 {
-	g_list_foreach(list, (GFunc)g_free, NULL);
-	g_list_free(list);
+	g_list_free_full (list, g_free);
 }
 
 

--- a/trashapplet/src/trashapplet.c
+++ b/trashapplet/src/trashapplet.c
@@ -583,10 +583,8 @@ trash_applet_drag_data_received (GtkWidget        *widget,
         }
     }
 
-  g_list_foreach (untrashable, (GFunc)g_object_unref, NULL);
-  g_list_free (untrashable);
-  g_list_foreach (trashed, (GFunc)g_object_unref, NULL);
-  g_list_free (trashed);
+  g_list_free_full (untrashable, g_object_unref);
+  g_list_free_full (trashed, g_object_unref);
 
   g_strfreev (list);
 


### PR DESCRIPTION
```C
void
g_list_free_full (GList *list,
                  GDestroyNotify free_func);
```
Convenience method, which frees all the memory used
by a GList, and calls `free_func` on every element's
data.

https://developer.gnome.org/glib/stable/glib-Doubly-Linked-Lists.html#g-list-free-full