### PR TITLE
Fix use-after-free clang warning

### DIFF
--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -750,9 +750,9 @@ destroy_applet( GtkWidget *widget, ProgressData *battstat )
   g_object_unref( G_OBJECT(battstat->status) );
   g_object_unref( G_OBJECT(battstat->percent) );
 
-  g_free( battstat );
-
   static_global_teardown (battstat);
+
+  g_free (battstat);
 }
 
 /* Common function invoked by the 'Help' context menu item and the 'Help'

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -668,10 +668,12 @@ void stickynotes_remove(StickyNote *note)
 	if (stickynote_get_empty(note)
 	    || !g_settings_get_boolean (stickynotes->settings, "confirm-deletion")
 	    || gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_OK) {
-		stickynote_free(note);
 
 		/* Remove the note from the linked-list of all notes */
-		stickynotes->notes = g_list_remove(stickynotes->notes, note);
+		stickynotes->notes = g_list_remove_all (stickynotes->notes, note);
+
+		/* Destroy the note */
+		stickynote_free (note);
 
 		/* Update tooltips */
 		stickynotes_applet_update_tooltips();


### PR DESCRIPTION
```
battstat_applet.c:755:3: warning: Use of memory after it is freed
  static_global_teardown (battstat);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
stickynotes.c:674:24: warning: Use of memory after it is freed
                stickynotes->notes = g_list_remove(stickynotes->notes, note);
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```