### PR TITLE
Help: Use XInclude instead of ENTITY for legal.xml

### DIFF
--- a/accessx-status/docs/C/index.docbook
+++ b/accessx-status/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" 
 "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY applet "Keyboard Accessibility Monitor">
 ]>
 
@@ -50,8 +49,7 @@
 		<publishername>GNOME Documentation Project</publishername>
 	 </publisher>
 
-&legal;
-
+	 <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
 	 <authorgroup>
 	 	<author>

--- a/battstat/docs/C/index.docbook
+++ b/battstat/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY applet "Battery Charge Monitor">
 ]>
@@ -66,10 +65,7 @@
       <publishername> GNOME Documentation Project </publishername>
     </publisher>
   
-    &legal;
-<!-- This file  contains link to license for the documentation (GNU FDL), and 
-     other legal stuff such as "NO WARRANTY" statement. Please do not change 
-     any of this. -->
+    <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
     <authorgroup>
       <author>

--- a/charpick/help/C/index.docbook
+++ b/charpick/help/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><!-- -*- indent-tabs-mode: nil -*- -->
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN" 
 "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY manrevision "2.11">
   <!ENTITY date "July 2015">
@@ -53,11 +52,8 @@
     <publishername>GNOME Documentation Project</publishername>
   </publisher>
 
-  &legal;
+  <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
-   <!-- This file  contains link to license for the documentation (GNU FDL), and 
-        other legal stuff such as "NO WARRANTY" statement. Please do not change 
-	any of this. -->
    <authorgroup>
      <author>
        <firstname>MATE Documentation Team</firstname>

--- a/cpufreq/help/C/index.docbook
+++ b/cpufreq/help/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY applet "CPU Frequency Scaling Monitor">
 ]>
@@ -49,10 +48,7 @@
 		<publishername>GNOME Documentation Project</publishername>
 	 </publisher> 
 
-&legal;
-<!-- This file  contains link to license for the documentation (GNU FDL), and 
-     other legal stuff such as "NO WARRANTY" statement. Please do not change 
-     any of this. -->
+	 <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
 	 <authorgroup> 
             <author>

--- a/drivemount/help/C/index.docbook
+++ b/drivemount/help/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appversion "1.10.2">
   <!ENTITY manrevision "2.12">
   <!ENTITY date "July 2015">
@@ -61,10 +60,7 @@
       <publishername> GNOME Documentation Project </publishername>
     </publisher>
 
-   &legal;
-   <!-- This file  contains link to license for the documentation (GNU FDL), and 
-        other legal stuff such as "NO WARRANTY" statement. Please do not change 
-	any of this. -->
+    <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
     <authorgroup> 
       <author>

--- a/geyes/docs/C/index.docbook
+++ b/geyes/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY manrevision "2.8">
   <!ENTITY date "July 2015">
@@ -58,7 +57,8 @@
 	 <publisher>
 		<publishername>GNOME Documentation Project</publishername>
 	 </publisher>
-&legal;
+
+	 <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
 	 <authorgroup> 
 		<author> 

--- a/mateweather/docs/C/index.docbook
+++ b/mateweather/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY applet "Weather Report">
 ]>
@@ -73,10 +72,8 @@ customizable.</para>
       <publisher>
 		<publishername> GNOME Documentation Project </publishername>
       </publisher>
-        &legal;
-      <!-- This file  contains link to license for the documentation (GNU FDL), and 
-           other legal stuff such as "NO WARRANTY" statement. Please do not change 
-           any of this. -->
+
+      <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
       	 
       <authorgroup>
 	<author>

--- a/multiload/docs/C/index.docbook
+++ b/multiload/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY manrevision "2.12">
   <!ENTITY date "July 2015">
@@ -57,10 +56,7 @@
       <publishername> GNOME Documentation Project </publishername>
     </publisher>
 
-    &legal;
-<!-- This file  contains link to license for the documentation (GNU FDL), and
-     other legal stuff such as "NO WARRANTY" statement. Please do not change
-     any of this. -->
+    <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
     <authorgroup>
 

--- a/netspeed/help/C/index.docbook
+++ b/netspeed/help/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN"
 "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.1">
   <!ENTITY manrevision "1.3">
   <!ENTITY date "July 2015">
@@ -47,7 +46,7 @@
       <publishername>GNOME Documentation Project</publishername> 
     </publisher>
 
-	&legal;
+    <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
     
     <authorgroup>
 	  <author role="maintainer">

--- a/stickynotes/docs/C/index.docbook
+++ b/stickynotes/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY applet "Sticky Notes">
 ]>
@@ -62,8 +61,8 @@ Template last modified Mar 12, 2002
 	<publisher>
 	    <publishername>GNOME Documentation Project</publishername>
 	</publisher>
-	
-	&legal;
+
+	<xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
 	<authorgroup>
           <author>

--- a/trashapplet/docs/C/index.docbook
+++ b/trashapplet/docs/C/index.docbook
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
 "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
   <!ENTITY appletversion "1.10.2">
   <!ENTITY manrevision "2.12">
   <!ENTITY date "July 2015">
@@ -50,10 +49,7 @@
 		<publishername> GNOME Documentation Project </publishername>
 	 </publisher>
 
-&legal;
-<!-- This file  contains link to license for the documentation (GNU FDL), and 
-     other legal stuff such as "NO WARRANTY" statement. Please do not change 
-     any of this. -->
+	 <xi:include href="legal.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 
 	 <authorgroup> 
 		<author> 


### PR DESCRIPTION
The ENTITY is expanded in i18n process, and legal.xml file
is never read.

Example `diff /usr/share/help/ca/mate-geyes/index.docbook geyes/docs/ca/index.docbook `
```diff
3d2
< <!ENTITY legal SYSTEM "legal.xml">
43,58d41
<   <legalnotice id="legalnotice">
< 	<para>Es concedeix el permís per copiar, distribuir i / o modificar aquest document sota els termes de la GFDL (GNU Free Documentation License), versió 1.1 o qualsevol versió posterior publicada per la Free Software Foundation que tinguin les seccions invariants, i sense cap text a la portada. Podeu trobar una còpia de la GFDL en aquest <ulink type="help" url="help:fdl">enllaç</ulink> o bé al fitxer COPYING-DOCS que es distribueix amb aquest manual.</para>
<          <para>Aquest manual forma part d'una col·lecció de manuals de MATE que estan distribuïts sota la GFDL. Si voleu distribuir aquest manual per separat de la col·lecció, podeu fer-ho afegint una còpia de la llicència al manual, tal com es descriu a la secció 6 de la llicència.</para>
< 
< 	<para>Molts dels noms utilitzats per les empreses per distingir els seus productes i serveis es consideren marques comercials. Quan aquests noms apareixen en qualsevol documentació de MATE, i els membres del projecte de documentació de MATE en són conscients, els noms tenen lletres majúscules o bé comencen en majúscules.</para>
< 
< 	<para>EL DOCUMENT I LES VERSIONS MODIFICADES DEL DOCUMENT S'OFEREIXEN SOTA ELS TERMES DE LA LLICÈNCIA DE DOCUMENTACIÓ LLIURE DE GNU, TENINT EN COMPTE QUE: <orderedlist>
< 		<listitem>
< 		  <para>EL DOCUMENT S'OFEREIX «TAL COM ÉS», SENSE CAP TIPUS DE GARANTIA, NI EXPLÍCITA NI IMPLÍCITA; AIXÒ INCLOU, SENSE LIMITAR-S'HI, LES GARANTIES QUE EL DOCUMENT O LA VERSIÓ MODIFICADA DEL DOCUMENT NO TINGUI DEFECTES, SIGUI COMERCIALITZABLE, SIGUI ADEQUAT PER A UN ÚS CONCRET O NO INFRINGEIXI CAP LLEI. TOT EL RISC PEL QUE FA A LA QUALITAT, EXACTITUD I RENDIMENT DEL DOCUMENT O LA VERSIÓ MODIFICADA DEL DOCUMENT ÉS VOSTRE. EN CAS QUE EL DOCUMENT RESULTÉS DEFECTUÓS EN QUALSEVOL ASPECTE, VÓS (NO PAS L'ESCRIPTOR INICIAL, L'AUTOR O CAP ALTRE COL·LABORADOR) ASSUMIU TOT EL COST DE MANTENIMENT, REPARACIÓ O CORRECCIÓ. AQUESTA RENÚNCIA DE GARANTIA CONSTITUEIX UNA PART ESSENCIAL D'AQUESTA LLICÈNCIA. NO S'AUTORITZA L'ÚS DE CAP DOCUMENT O VERSIÓ MODIFICADA DEL DOCUMENT EXCEPTE SOTA AQUESTA RENÚNCIA DE GARANTIA; I</para>
< 		</listitem>
< 		<listitem>
< 		  <para>EN CAP CAS I SOTA CAP INTERPRETACIÓ LEGAL, JA SIGUI PER AGREUJAMENT (INCLOENT-HI LA NEGLIGÈNCIA), CONTRACTE O ALTRE CAS, L'AUTOR, L'ESCRIPTOR ORIGINAL, QUALSEVOL DELS COL·LABORADORS O DISTRIBUÏDORS DEL DOCUMENT O UNA VERSIÓ MODIFICADA DEL DOCUMENT NI CAP PROVEÏDOR D'AQUESTES PARTS NO SERAN RESPONSABLES DAVANT DE NINGÚ PER CAP DANY DIRECTE, INDIRECTE, ESPECIAL, ACCIDENTAL O CONSECUTIU DE QUALSEVOL TIPUS; AIXÒ INCLOU, SENSE LIMITAR-S'HI, ELS DANYS PER PÈRDUA DE CLIENTS, INTERRUPCIONS DE LA FEINA, FALLADA O MALFUNCIONAMENT DE L'ORDINADOR, O QUALSEVOL ALTRA PÈRDUA O DANY RELACIONAT AMB L'ÚS DEL DOCUMENT I LES VERSIONS MODIFICADES DEL DOCUMENT, FINS I TOT SI S'HA INFORMAT AQUESTA PART DE LA POSSIBILITAT D'AQUESTS DANYS.</para>
< 		</listitem>
< 	  </orderedlist></para>
<   </legalnotice>
< 
59a43
> 	 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="legal.xml"/>
```
File size of index.docbook, in the example:
```sh
[robert@localhost mate-applets]$ LANG=C ls -la /usr/share/help/ca/mate-geyes/*.{docbook,xml}
-rw-r--r--. 1 root root 12480 Mar  4 23:15 /usr/share/help/ca/mate-geyes/index.docbook
-rw-r--r--. 1 root root  3038 Mar  4 23:15 /usr/share/help/ca/mate-geyes/legal.xml
[robert@localhost mate-applets]$ LANG=C ls -la geyes/docs/ca/*.{docbook,xml}
-rw-rw-r--. 1 robert robert 9519 Mar 14 11:37 geyes/docs/ca/index.docbook
-rw-rw-r--. 1 robert robert 3038 Mar 14 11:37 geyes/docs/ca/legal.xml
```