### PR TITLE
multiload: Use /proc/diskstats for NVMe drives

### DIFF
--- a/multiload/org.mate.panel.applet.multiload.gschema.xml.in
+++ b/multiload/org.mate.panel.applet.multiload.gschema.xml.in
@@ -141,6 +141,10 @@
       <default>'#000000'</default>
       <summary>Background color for disk load graph</summary>
     </key>
+    <key name="diskload-nvme-diskstats" type="b">
+      <default>false</default>
+      <summary>Uses /proc/diskstats to determine NVMe disk load</summary>
+    </key>
     <key name="system-monitor" type="s">
       <default>'mate-system-monitor.desktop'</default>
       <summary>The desktop description file to execute as the system monitor</summary>


### PR DESCRIPTION
Since glibtop does not support NVMe drives, we rely on /proc/diskstats
to tell use load information for NVMe drives. If diskstats is not
present it returns to glibtop as a fallback.

This also adds a preference to toggle this behavior (default is glibtop).

Fixes #290 