### PR TITLE
Make cpufreq builds independent from kernel header version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,33 +357,51 @@ if test "x$HAVE_POLKIT" = "xyes"; then
    enable_suid=no
 fi
 
-AC_ARG_WITH([cpufreq-lib],
-	AS_HELP_STRING([--with-cpufreq-lib=lib], [library to use for cpufreq applet @<:@default=cpufreq@:>@]),
-	[with_cpufreq_lib=$withval], [with_cpufreq_lib="cpupower"])
+build_cpufreq_applet=yes
+AS_IF([test "x$disable_cpufreq" = "xno"], [
+  case "${host}" in
+    *linux*)
+      AC_CHECK_HEADER([cpufreq.h], [
+        AC_CHECK_LIB([cpupower], [cpupower_is_cpu_online], [
+          AC_DEFINE([HAVE_IS_CPU_ONLINE], 1,
+                    [Define to 1 if cpupower_is_cpu_online() is available])
+          cpufreq_lib="cpupower"
 
-AC_CHECK_HEADER(cpufreq.h, have_libcpufreq=yes, have_libcpufreq=no)
-LIBCPUFREQ_LIBS=
-if test "x$have_libcpufreq" = "xyes"; then
-   AC_DEFINE([HAVE_LIBCPUFREQ], [1], [Have libcpufreq.])
-   LIBCPUFREQ_LIBS="-l$with_cpufreq_lib"
-fi
-AM_CONDITIONAL(HAVE_LIBCPUFREQ, test x$have_libcpufreq = xyes)
-AC_SUBST(LIBCPUFREQ_LIBS)
+          AC_CHECK_LIB([cpupower], [cpufreq_get_frequencies], [
+            AC_DEFINE([HAVE_GET_FREQUENCIES], 1,
+                      [Define to 1 if cpufreq_get_frequencies() is available])
+          ])
+        ], [
+          AC_CHECK_LIB([cpupower], [cpufreq_cpu_exists], [
+            cpufreq_lib="cpupower"
+          ], [
+            AC_CHECK_LIB([cpufreq], [cpufreq_cpu_exists], [
+              cpufreq_lib="cpufreq"
+            ], [cpufreq_lib=])
+          ])
+        ])
 
-build_cpufreq_applet=no
+        AS_IF([test "x$cpufreq_lib" != "x"], [
+          LIBCPUFREQ_LIBS="-l$cpufreq_lib"
+          AC_DEFINE([HAVE_LIBCPUFREQ], [1], [Have libcpufreq.])
+          AC_SUBST([LIBCPUFREQ_LIBS])
+        ], [
+          AC_MSG_WARN([*** cpufreq applet will not be built ***])
+          build_cpufreq_applet=no
+        ])
+      ], [
+        AC_MSG_WARN([*** can't find cpufreq.h, cpufreq applet will not be built ***])
+        build_cpufreq_applet=no
+      ])
+      ;;
+    *)
+      AC_MSG_WARN([${host} is not supported by cpufreq applet, not building])
+      build_cpufreq_applet=no
+      ;;
+  esac
+], [build_cpufreq_applet=no])
 
-if test x$disable_cpufreq = xno; then
-   case "${host}" in
-      *linux*)
-         build_cpufreq_applet=yes
-	 ;;
-      *)
-         AC_MSG_WARN([${host} is not supported by cpufreq applet, not building])
-	 build_cpufreq_applet=no
-	 ;;
-   esac
-fi
-
+AM_CONDITIONAL(HAVE_LIBCPUFREQ, test x$cpufreq_lib != x)
 AM_CONDITIONAL(BUILD_CPUFREQ_APPLET, test x$build_cpufreq_applet = xyes)
 AM_CONDITIONAL(BUILD_CPUFREQ_SELECTOR, test x$enable_selector = xyes)
 AM_CONDITIONAL(CPUFREQ_SELECTOR_SUID, test x$enable_suid = xyes)

--- a/cpufreq/src/cpufreq-monitor-libcpufreq.c
+++ b/cpufreq/src/cpufreq-monitor-libcpufreq.c
@@ -19,11 +19,14 @@
  * Authors : Carlos García Campos <carlosgc@gnome.org>
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <glib.h>
 #include <glib/gi18n.h>
 
 #include <stdlib.h>
-#include <linux/version.h>
 #include <cpufreq.h>
 #include "cpufreq-monitor-libcpufreq.h"
 #include "cpufreq-utils.h"
@@ -36,12 +39,12 @@ static GList   *cpufreq_monitor_libcpufreq_get_available_governors   (CPUFreqMon
 
 G_DEFINE_TYPE (CPUFreqMonitorLibcpufreq, cpufreq_monitor_libcpufreq, CPUFREQ_TYPE_MONITOR)
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
-typedef struct cpufreq_available_frequencies CPUFreqFrequencyList;
-#else
+#ifdef HAVE_GET_FREQUENCIES
 typedef struct cpufreq_frequencies CPUFreqFrequencyList;
 #define cpufreq_get_available_frequencies(cpu) cpufreq_get_frequencies ("available", cpu)
 #define cpufreq_put_available_frequencies(first) cpufreq_put_frequencies (first)
+#else
+typedef struct cpufreq_available_frequencies CPUFreqFrequencyList;
 #endif
 
 typedef struct cpufreq_policy                CPUFreqPolicy;
@@ -105,7 +108,7 @@ cpufreq_monitor_libcpufreq_new (guint cpu)
         return CPUFREQ_MONITOR (monitor);
 }
 
-#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 7, 0)
+#ifdef HAVE_IS_CPU_ONLINE
 extern int cpupower_is_cpu_online (unsigned int cpu);
 #endif
 
@@ -122,7 +125,7 @@ cpufreq_monitor_libcpufreq_run (CPUFreqMonitor *monitor)
 		/* Check whether it failed because
 		 * cpu is not online.
 		 */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+#ifndef HAVE_IS_CPU_ONLINE
 		if (!cpufreq_cpu_exists (cpu)) {
 #else
 		if (cpupower_is_cpu_online (cpu)) {

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
@@ -19,6 +19,10 @@
  * Authors : Carlos García Campos <carlosgc@gnome.org>
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <cpufreq.h>
@@ -39,12 +43,12 @@ static gboolean cpufreq_selector_libcpufreq_set_governor  (CPUFreqSelector      
 
 G_DEFINE_TYPE (CPUFreqSelectorLibcpufreq, cpufreq_selector_libcpufreq, CPUFREQ_TYPE_SELECTOR)
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
-typedef struct cpufreq_available_frequencies CPUFreqFrequencyList;
-#else
+#ifdef HAVE_GET_FREQUENCIES
 typedef struct cpufreq_frequencies CPUFreqFrequencyList;
 #define cpufreq_get_available_frequencies(cpu) cpufreq_get_frequencies ("available", cpu)
 #define cpufreq_put_available_frequencies(first) cpufreq_put_frequencies (first)
+#else
+typedef struct cpufreq_available_frequencies CPUFreqFrequencyList;
 #endif
 
 typedef struct cpufreq_policy                CPUFreqPolicy;


### PR DESCRIPTION
  Ported from gnome-applets, see

    git diff e48b2d73~..5882df7f cpufreq/ configure.ac

  on the gnome-applets repository.

  Fixes mate-desktop/mate-applets#238.