### PR TITLE
drivemount: remove -Wformat-nonliteral warning

### DIFF
--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -615,7 +615,7 @@ open_drive (DriveButton *self, GtkWidget *item)
 						     GTK_BUTTONS_OK,
 						     _("Cannot execute Caja"));
 	if (error)
-	    gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), error->message, NULL);
+	    gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "%s", error->message);
 	else
 	    gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), "Could not find Caja");
 	g_signal_connect (dialog, "response",


### PR DESCRIPTION
```
drive-button.c:618:6: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  618 |      gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog), error->message, NULL);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```