### PR TITLE
cpufreq: remove -Wabsolute-value warning

### DIFF
--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
@@ -106,7 +106,7 @@ cpufreq_selector_libcpufreq_get_valid_frequency (CPUFreqSelectorLibcpufreq *sele
 			return frequency;
 		}
 
-		current_dist = abs (freq->frequency - frequency);
+		current_dist = abs ((int)freq->frequency - (int)frequency);
 		if (current_dist < dist) {
 			dist = current_dist;
 			retval = freq->frequency;

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-procfs.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-procfs.c
@@ -184,7 +184,7 @@ cpufreq_selector_procfs_set_frequency (CPUFreqSelector *selector,
 	}
 
 	if (frequency != sc_max && frequency != sc_min) {
-		if (abs (sc_max - frequency) < abs (frequency - sc_min))
+		if (abs ((int)sc_max - (int)frequency) < abs ((int)frequency - (int)sc_min))
 			freq = sc_max;
 		else
 			freq = sc_min;

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
@@ -241,7 +241,7 @@ cpufreq_selector_sysfs_get_valid_frequency (CPUFreqSelectorSysfs *selector,
 		if (f == frequency)
 			return freq;
 
-		current_dist = abs (frequency - f);
+		current_dist = abs ((int)frequency - (int)f);
 		if (current_dist < dist) {
 			dist = current_dist;
 			retval = freq;


### PR DESCRIPTION
```
cpufreq-selector-sysfs.c:244:18: warning: taking the absolute value of unsigned type ‘guint’ {aka ‘unsigned int’} has no effect [-Wabsolute-value]
  244 |   current_dist = abs (frequency - f);
      |                  ^~~
--
cpufreq-selector-procfs.c:187:7: warning: taking the absolute value of unsigned type ‘guint’ {aka ‘unsigned int’} has no effect [-Wabsolute-value]
  187 |   if (abs (sc_max - frequency) < abs (frequency - sc_min))
      |       ^~~
cpufreq-selector-procfs.c:187:34: warning: taking the absolute value of unsigned type ‘guint’ {aka ‘unsigned int’} has no effect [-Wabsolute-value]
  187 |   if (abs (sc_max - frequency) < abs (frequency - sc_min))
      |                                  ^~~
--
cpufreq-selector-libcpufreq.c:109:18: warning: taking the absolute value of unsigned type ‘long unsigned int’ has no effect [-Wabsolute-value]
  109 |   current_dist = abs (freq->frequency - frequency);
      |                  ^~~
```