### PR TITLE
ci: add cpupower build dependency to archlinux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/mate-applets
     - clang
+    - cpupower
     - gcc
     - git
     - gucharmap


### PR DESCRIPTION
Now it can found the cpupower library when building:
https://travis-ci.org/mate-desktop/mate-applets/jobs/587805787#L875