### PR TITLE
build: fix building cpufreq-applet for s390x arch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,9 +390,6 @@ AS_IF([test "x$disable_cpufreq" = "xno"], [
           AC_MSG_WARN([*** cpufreq applet will not be built ***])
           build_cpufreq_applet=no
         ])
-      ], [
-        AC_MSG_WARN([*** can't find cpufreq.h, cpufreq applet will not be built ***])
-        build_cpufreq_applet=no
       ])
       ;;
     *)


### PR DESCRIPTION
Don't stop building when cpufreq.h isn't available.