### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/battstat/power-management.c
+++ b/battstat/power-management.c
@@ -292,9 +292,6 @@ static int acpi_count;
 static int acpiwatch;
 static struct apm_info apminfo;
 
-/* Declared in acpi-linux.c */
-gboolean acpi_linux_read(struct apm_info *apminfo, struct acpi_info *acpiinfo);
-
 static gboolean acpi_callback (GIOChannel * chan, GIOCondition cond, gpointer data)
 {
   if (cond & (G_IO_ERR | G_IO_HUP)) {

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -74,9 +74,6 @@ struct _CPUFreqAppletClass {
         MatePanelAppletClass parent_class;
 };
 
-static void     cpufreq_applet_init              (CPUFreqApplet      *applet);
-static void     cpufreq_applet_class_init        (CPUFreqAppletClass *klass);
-
 static void     cpufreq_applet_preferences_cb    (GtkAction          *action,
                                                   CPUFreqApplet      *applet);
 static void     cpufreq_applet_help_cb           (GtkAction          *action,

--- a/cpufreq/src/cpufreq-monitor-cpuinfo.c
+++ b/cpufreq/src/cpufreq-monitor-cpuinfo.c
@@ -32,8 +32,6 @@
 #include "cpufreq-monitor-cpuinfo.h"
 #include "cpufreq-utils.h"
 
-static void     cpufreq_monitor_cpuinfo_class_init (CPUFreqMonitorCPUInfoClass *klass);
-
 static gboolean cpufreq_monitor_cpuinfo_run        (CPUFreqMonitor *monitor);
 
 G_DEFINE_TYPE (CPUFreqMonitorCPUInfo, cpufreq_monitor_cpuinfo, CPUFREQ_TYPE_MONITOR)

--- a/cpufreq/src/cpufreq-monitor-libcpufreq.c
+++ b/cpufreq/src/cpufreq-monitor-libcpufreq.c
@@ -31,8 +31,6 @@
 #include "cpufreq-monitor-libcpufreq.h"
 #include "cpufreq-utils.h"
 
-static void     cpufreq_monitor_libcpufreq_class_init                (CPUFreqMonitorLibcpufreqClass *klass);
-
 static gboolean cpufreq_monitor_libcpufreq_run                       (CPUFreqMonitor *monitor);
 static GList   *cpufreq_monitor_libcpufreq_get_available_frequencies (CPUFreqMonitor *monitor);
 static GList   *cpufreq_monitor_libcpufreq_get_available_governors   (CPUFreqMonitor *monitor);

--- a/cpufreq/src/cpufreq-monitor-procfs.c
+++ b/cpufreq/src/cpufreq-monitor-procfs.c
@@ -29,8 +29,6 @@
 #include "cpufreq-monitor-procfs.h"
 #include "cpufreq-utils.h"
 
-static void     cpufreq_monitor_procfs_class_init                (CPUFreqMonitorProcfsClass *klass);
-
 static gboolean cpufreq_monitor_procfs_run                       (CPUFreqMonitor       *monitor);
 static GList   *cpufreq_monitor_procfs_get_available_frequencies (CPUFreqMonitor       *monitor);
 

--- a/cpufreq/src/cpufreq-monitor-sysfs.c
+++ b/cpufreq/src/cpufreq-monitor-sysfs.c
@@ -38,8 +38,6 @@ enum {
         N_FILES
 };
 
-static void     cpufreq_monitor_sysfs_class_init                (CPUFreqMonitorSysfsClass *klass);
-
 static gboolean cpufreq_monitor_sysfs_run                       (CPUFreqMonitor *monitor);
 static GList   *cpufreq_monitor_sysfs_get_available_frequencies (CPUFreqMonitor *monitor);
 static GList   *cpufreq_monitor_sysfs_get_available_governors   (CPUFreqMonitor *monitor);

--- a/cpufreq/src/cpufreq-monitor.c
+++ b/cpufreq/src/cpufreq-monitor.c
@@ -52,8 +52,6 @@ struct _CPUFreqMonitorPrivate {
         gboolean changed;
 };
 
-static void   cpufreq_monitor_init         (CPUFreqMonitor      *monitor);
-static void   cpufreq_monitor_class_init   (CPUFreqMonitorClass *klass);
 static void   cpufreq_monitor_finalize     (GObject             *object);
 
 static void   cpufreq_monitor_set_property (GObject             *object,

--- a/cpufreq/src/cpufreq-popup.c
+++ b/cpufreq/src/cpufreq-popup.c
@@ -48,8 +48,6 @@ struct _CPUFreqPopupPrivate {
 	GtkWidget           *parent;
 };
 
-static void cpufreq_popup_init       (CPUFreqPopup      *popup);
-static void cpufreq_popup_class_init (CPUFreqPopupClass *klass);
 static void cpufreq_popup_finalize   (GObject           *object);
 
 G_DEFINE_TYPE_WITH_PRIVATE (CPUFreqPopup, cpufreq_popup, G_TYPE_OBJECT)

--- a/cpufreq/src/cpufreq-prefs.c
+++ b/cpufreq/src/cpufreq-prefs.c
@@ -54,8 +54,6 @@ struct _CPUFreqPrefsPrivate {
 	GtkWidget *show_mode_combo;
 };
 
-static void cpufreq_prefs_init                      (CPUFreqPrefs      *prefs);
-static void cpufreq_prefs_class_init                (CPUFreqPrefsClass *klass);
 static void cpufreq_prefs_finalize                  (GObject           *object);
 
 static void cpufreq_prefs_set_property              (GObject           *object,

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-libcpufreq.c
@@ -31,9 +31,6 @@
 
 #include "cpufreq-selector-libcpufreq.h"
 
-static void     cpufreq_selector_libcpufreq_init          (CPUFreqSelectorLibcpufreq      *selector);
-static void     cpufreq_selector_libcpufreq_class_init    (CPUFreqSelectorLibcpufreqClass *klass);
-
 static gboolean cpufreq_selector_libcpufreq_set_frequency (CPUFreqSelector           *selector,
 							   guint                      frequency,
 							   GError                   **error);

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-procfs.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-procfs.c
@@ -27,9 +27,6 @@
 
 #include "cpufreq-selector-procfs.h"
 
-static void     cpufreq_selector_procfs_init          (CPUFreqSelectorProcfs      *selector);
-static void     cpufreq_selector_procfs_class_init    (CPUFreqSelectorProcfsClass *klass);
-
 static gboolean cpufreq_selector_procfs_set_frequency (CPUFreqSelector            *selector,
 						       guint                       frequency,
 						       GError                    **error);

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector-sysfs.c
@@ -31,8 +31,6 @@ struct _CPUFreqSelectorSysfsPrivate {
 	GList *available_govs;
 };
 
-static void     cpufreq_selector_sysfs_init          (CPUFreqSelectorSysfs      *selector);
-static void     cpufreq_selector_sysfs_class_init    (CPUFreqSelectorSysfsClass *klass);
 static void     cpufreq_selector_sysfs_finalize      (GObject                   *object);
 
 static gboolean cpufreq_selector_sysfs_set_frequency (CPUFreqSelector           *selector,

--- a/cpufreq/src/cpufreq-selector/cpufreq-selector.c
+++ b/cpufreq/src/cpufreq-selector/cpufreq-selector.c
@@ -31,9 +31,6 @@ struct _CPUFreqSelectorPrivate {
 	guint  cpu;
 };
 
-static void cpufreq_selector_init         (CPUFreqSelector      *selector);
-static void cpufreq_selector_class_init   (CPUFreqSelectorClass *klass);
-
 static void cpufreq_selector_set_property (GObject              *object,
 					   guint                 prop_id,
 					   const GValue         *value,

--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -400,11 +400,14 @@ drive_button_update (gpointer user_data)
         pixels = cairo_image_surface_get_data (tmp_surface);
 
         GdkRGBA color;
+        GSettings *settings;
+        settings = g_settings_new ("org.mate.drivemount");
         gchar *color_string = g_settings_get_string (settings, "drivemount-checkmark-color");
         if (!color_string)
                 color_string = g_strdup ("#00ff00");
         gdk_rgba_parse (&color, color_string);
         g_free (color_string);
+        g_object_unref (settings);
 
         guchar red = color.red*255;
         guchar green = color.green*255;

--- a/drivemount/drive-button.h
+++ b/drivemount/drive-button.h
@@ -63,7 +63,7 @@ void       drive_button_set_size        (DriveButton *button,
 
 int        drive_button_compare         (DriveButton *button,
 					 DriveButton *other_button);
-GSettings  *settings;
+
 void       drive_button_redraw (gpointer key, gpointer value, gpointer user_data);
 
 G_END_DECLS


### PR DESCRIPTION
Fixes the warnings:

```
drive-button.h:66:13: warning: redundant redeclaration of ‘settings’ [-Wredundant-decls]
power-management.c:296:10: warning: redundant redeclaration of ‘acpi_linux_read’ [-Wredundant-decls]
cpufreq-selector.c:46:55: warning: redundant redeclaration of ‘cpufreq_selector_init’ [-Wredundant-decls]
cpufreq-selector.c:46:55: warning: redundant redeclaration of ‘cpufreq_selector_class_init’ [-Wredundant-decls]
cpufreq-selector-sysfs.c:47:51: warning: redundant redeclaration of ‘cpufreq_selector_sysfs_init’ [-Wredundant-decls]
cpufreq-selector-sysfs.c:47:51: warning: redundant redeclaration of ‘cpufreq_selector_sysfs_class_init’ [-Wredundant-decls]
cpufreq-selector-procfs.c:40:39: warning: redundant redeclaration of ‘cpufreq_selector_procfs_init’ [-Wredundant-decls]
cpufreq-selector-procfs.c:40:39: warning: redundant redeclaration of ‘cpufreq_selector_procfs_class_init’ [-Wredundant-decls]
cpufreq-selector-libcpufreq.c:44:43: warning: redundant redeclaration of ‘cpufreq_selector_libcpufreq_init’ [-Wredundant-decls]
cpufreq-selector-libcpufreq.c:44:43: warning: redundant redeclaration of ‘cpufreq_selector_libcpufreq_class_init’ [-Wredundant-decls]
cpufreq-applet.c:130:31: warning: redundant redeclaration of ‘cpufreq_applet_init’ [-Wredundant-decls]
cpufreq-applet.c:130:31: warning: redundant redeclaration of ‘cpufreq_applet_class_init’ [-Wredundant-decls]
cpufreq-prefs.c:73:43: warning: redundant redeclaration of ‘cpufreq_prefs_init’ [-Wredundant-decls]
cpufreq-prefs.c:73:43: warning: redundant redeclaration of ‘cpufreq_prefs_class_init’ [-Wredundant-decls]
cpufreq-monitor.c:70:54: warning: redundant redeclaration of ‘cpufreq_monitor_init’ [-Wredundant-decls]
cpufreq-monitor.c:70:54: warning: redundant redeclaration of ‘cpufreq_monitor_class_init’ [-Wredundant-decls]
cpufreq-popup.c:55:43: warning: redundant redeclaration of ‘cpufreq_popup_init’ [-Wredundant-decls]
cpufreq-popup.c:55:43: warning: redundant redeclaration of ‘cpufreq_popup_class_init’ [-Wredundant-decls]
cpufreq-monitor-procfs.c:37:38: warning: redundant redeclaration of ‘cpufreq_monitor_procfs_class_init’ [-Wredundant-decls]
cpufreq-monitor-sysfs.c:69:37: warning: redundant redeclaration of ‘cpufreq_monitor_sysfs_class_init’ [-Wredundant-decls]
cpufreq-monitor-libcpufreq.c:40:42: warning: redundant redeclaration of ‘cpufreq_monitor_libcpufreq_class_init’ [-Wredundant-decls]
cpufreq-monitor-cpuinfo.c:39:39: warning: redundant redeclaration of ‘cpufreq_monitor_cpuinfo_class_init’ [-Wredundant-decls]
```