### PR TITLE
Fix build using gcc 10 -fno-common flag

### DIFF
--- a/drivemount/drive-list.c
+++ b/drivemount/drive-list.c
@@ -32,6 +32,8 @@
 
 G_DEFINE_TYPE (DriveList, drive_list, GTK_TYPE_GRID);
 
+GSettings *settings;
+
 static GVolumeMonitor *volume_monitor = NULL;
 
 static void drive_list_finalize (GObject *object);
@@ -152,6 +154,8 @@ drive_list_finalize (GObject *object)
 
     g_hash_table_destroy (self->volumes);
     g_hash_table_destroy (self->mounts);
+
+    g_object_unref (settings);
 
     if (G_OBJECT_CLASS (drive_list_parent_class)->finalize)
 	(* G_OBJECT_CLASS (drive_list_parent_class)->finalize) (object);

--- a/drivemount/drive-list.h
+++ b/drivemount/drive-list.h
@@ -65,7 +65,7 @@ void       drive_list_set_panel_size  (DriveList *list,
 				       int panel_size);
 void       drive_list_set_transparent (DriveList *self,
 				       gboolean transparent);
-GSettings *settings;
+extern GSettings *settings;
 void       drive_list_redraw (DriveList *self);
 void       settings_color_changed (GSettings *settings, gchar *key, DriveList *drive_list);
 


### PR DESCRIPTION
```
/usr/bin/ld: drive-list.o:/home/robert/mate-applets/drivemount/drive-list.h:68: multiple definition of `settings'; drivemount.o:/home/robert/mate-applets/drivemount/drive-list.h:68: first defined here
```