### PR TITLE
build: show compiler flags on configuration summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -633,6 +633,8 @@ mate-applets-$VERSION configure summary:
     Prefix:                        ${prefix}
     Source code location:          ${srcdir}
     Compiler:                      ${CC}
+    Compiler flags:                ${CFLAGS}
+    Compiler warnings:             ${WARN_CFLAGS}
 
     Building:
         - accessx-status           $HAVE_XKB


### PR DESCRIPTION
```shell
$ ./autogen.sh --enable-compile-warnings=maximum
<cut>

mate-applets-1.23.1 configure summary:

    Prefix:                        /usr/local
    Source code location:          .
    Compiler:                      gcc
    Compiler flags:                -g -O2
    Compiler warnings:             -Wall -Wmissing-prototypes -Wbad-function-cast -Wcast-align -Wextra -Wformat-nonliteral -Wmissing-declarations -Wmissing-field-initializers -Wnested-externs -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-prototypes -Wno-sign-compare

    Building:
        - accessx-status           true
        - battstat                 yes
        - charpick                 always
            - gucharmap support    yes
        - cpufreq                  yes
            - building selector    yes
            - using PolicyKit      yes
            - enabling suid bit    no
        - drivemount               always
        - geyes                    always
        - mateweather              true
        - multiload                true
        - netspeed                 true
            - iwlib support        yes
        - stickynotes              yes
        - timerapplet              yes
        - trashapplet              always

    Using DBUS:                    yes
    Using UPOWER:                  yes
    Using libnotify:               yes
    Enabling IPv6:                 yes

Now type `make' to compile mate-applets
<cut>
```