### PR TITLE
drivemount: Remove global variable

### DIFF
--- a/drivemount/drive-list.c
+++ b/drivemount/drive-list.c
@@ -32,8 +32,6 @@
 
 G_DEFINE_TYPE (DriveList, drive_list, GTK_TYPE_GRID);
 
-GSettings *settings;
-
 static GVolumeMonitor *volume_monitor = NULL;
 
 static void drive_list_finalize (GObject *object);
@@ -89,8 +87,14 @@ drive_list_init (DriveList *self)
     self->mounts = g_hash_table_new (NULL, NULL);
     self->orientation = GTK_ORIENTATION_HORIZONTAL;
     self->layout_tag = 0;
+    self->settings = g_settings_new ("org.mate.drivemount");
     self->icon_size = 24;
     self->relief = GTK_RELIEF_NORMAL;
+
+    g_signal_connect(self->settings,
+                     "changed::drivemount-checkmark-color",
+                     G_CALLBACK (settings_color_changed),
+                     self);
 
     /* listen for drive connects/disconnects, and add
      * currently connected drives. */
@@ -154,8 +158,7 @@ drive_list_finalize (GObject *object)
 
     g_hash_table_destroy (self->volumes);
     g_hash_table_destroy (self->mounts);
-
-    g_object_unref (settings);
+    g_object_unref (self->settings);
 
     if (G_OBJECT_CLASS (drive_list_parent_class)->finalize)
 	(* G_OBJECT_CLASS (drive_list_parent_class)->finalize) (object);

--- a/drivemount/drive-list.h
+++ b/drivemount/drive-list.h
@@ -49,6 +49,8 @@ struct _DriveList
     GtkWidget *dummy;
     gint count;
 
+    GSettings *settings;
+
     int icon_size;
 };
 
@@ -65,7 +67,6 @@ void       drive_list_set_panel_size  (DriveList *list,
 				       int panel_size);
 void       drive_list_set_transparent (DriveList *self,
 				       gboolean transparent);
-extern GSettings *settings;
 void       drive_list_redraw (DriveList *self);
 void       settings_color_changed (GSettings *settings, gchar *key, DriveList *drive_list);
 

--- a/drivemount/drivemount.c
+++ b/drivemount/drivemount.c
@@ -189,13 +189,8 @@ applet_factory (MatePanelApplet *applet,
 	mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 	mate_panel_applet_set_background_widget (applet, GTK_WIDGET (applet));
 
-	settings = g_settings_new ( "org.mate.drivemount");
-
 	drive_list = drive_list_new ();
-    g_signal_connect(settings,
-                     "changed::drivemount-checkmark-color",
-                     G_CALLBACK (settings_color_changed),
-                     drive_list);
+
 	gtk_container_add (GTK_CONTAINER (applet), drive_list);
 
 	g_signal_connect_object (applet, "change_orient",


### PR DESCRIPTION
Test: setting check mark color on dconf-editor

![Captura de pantalla a 2020-02-09 00-08-03](https://user-images.githubusercontent.com/10171411/74093316-88620680-4ad0-11ea-96ff-0938aa982b47.png)
