### PR TITLE
build: drop unused locale stuff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,10 +244,6 @@ AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [Gettext Package])
 AC_DEFINE_DIR(MATELOCALEDIR, "${datadir}/locale", [locale directory])
 
-# this is the directory where the *.{mo,gmo} files are installed
-matelocaledir='${datadir}/locale'
-AC_SUBST(matelocaledir)
-
 dnl ***************************************************************************
 dnl *** yelp-tools                                                          ***
 dnl ***************************************************************************

--- a/netspeed/src/Makefile.am
+++ b/netspeed/src/Makefile.am
@@ -1,7 +1,6 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(includedir) \
        $(GIO_CFLAGS) $(GTOP_APPLETS_CFLAGS) \
        $(MATE_APPLETS4_CFLAGS) $(MATEDESKTOP_CFLAGS) \
-       -DMATELOCALEDIR=\""$(datadir)/locale"\" \
        -DNETSPEED_MENU_UI_DIR=\""$(datadir)/mate/ui"\"
 
 libexec_PROGRAMS = mate-netspeed-applet


### PR DESCRIPTION
Follow-up to #438.
How to test: check that all applets are still translated as before.