### PR TITLE
Remove unused-function warnings

### DIFF
--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -280,24 +280,6 @@ cpufreq_applet_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
         GTK_WIDGET_CLASS (cpufreq_applet_parent_class)->size_allocate (widget, allocation);
 }
 
-static gint
-get_max_text_width (GtkWidget *widget,
-                    const char *text)
-{
-	PangoContext *context;
-	PangoLayout *layout;
-	PangoRectangle logical_rect;
-
-	context = gtk_widget_get_pango_context (widget);
-	layout = pango_layout_new (context);
-	pango_layout_set_text (layout, text, -1);
-	pango_layout_get_pixel_extents (layout, NULL, &logical_rect);
-
-	g_object_unref (layout);
-
-	return logical_rect.width;
-}
-
 static void
 cpufreq_applet_menu_popup (CPUFreqApplet *applet,
                            guint32        time)
@@ -317,7 +299,7 @@ cpufreq_applet_menu_popup (CPUFreqApplet *applet,
 
         if (!menu)
                 return;
-                
+
         /*Set up theme and transparency support*/
         GtkWidget *toplevel = gtk_widget_get_toplevel (menu);
         /* Fix any failures of compiz/other wm's to communicate with gtk for transparency */

--- a/drivemount/drive-button.c
+++ b/drivemount/drive-button.c
@@ -153,36 +153,6 @@ drive_button_dispose (GObject *object)
 	(* G_OBJECT_CLASS (drive_button_parent_class)->dispose) (object);
 }
 
-#if 0
-static void
-drive_button_unrealize (GtkWidget *widget)
-{
-    DriveButton *self = DRIVE_BUTTON (widget);
-
-    drive_button_reset_popup (self);
-
-    if (GTK_WIDGET_CLASS (drive_button_parent_class)->unrealize)
-	(* GTK_WIDGET_CLASS (drive_button_parent_class)->unrealize) (widget);
-}
-#endif /* 0 */
-
-static int
-_gtk_get_monitor_num (GdkMonitor *monitor)
-{
-    GdkDisplay *display;
-    int n_monitors, i;
-
-    display = gdk_monitor_get_display(monitor);
-    n_monitors = gdk_display_get_n_monitors(display);
-
-    for(i = 0; i < n_monitors; i++)
-    {
-        if(gdk_display_get_monitor(display, i) == monitor) return i;
-    }
-
-    return -1;
-}
-
 static gboolean
 drive_button_button_press (GtkWidget      *widget,
 			   GdkEventButton *event)

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -119,16 +119,6 @@ update_tooltip(MateNetspeedApplet* applet);
 static void
 device_change_cb(GtkComboBox *combo, MateNetspeedApplet *applet);
 
-/* Adds a Pango markup "size" to a bytestring
- */
-static void
-add_markup_size(char **string, int size)
-{
-	char *tmp = *string;
-	*string = g_strdup_printf("<span size=\"%d\">%s</span>", size * 1000, tmp);
-	g_free(tmp);
-}
-
 /* Adds a Pango markup "foreground" to a bytestring
  */
 static void

--- a/trashapplet/src/trash-empty.c
+++ b/trashapplet/src/trash-empty.c
@@ -46,14 +46,6 @@ static gsize       volatile trash_empty_total_files;
 static gboolean    volatile trash_empty_update_pending;
 
 static gboolean
-trash_empty_clear_pending (gpointer user_data)
-{
-  trash_empty_update_pending = FALSE;
-
-  return FALSE;
-}
-
-static gboolean
 trash_empty_update_dialog (gpointer user_data)
 {
   gsize deleted, total;


### PR DESCRIPTION
```
drive-button.c:170:1: warning: ‘_gtk_get_monitor_num’ defined but not used [-Wunused-function]
  170 | _gtk_get_monitor_num (GdkMonitor *monitor)
      | ^~~~~~~~~~~~~~~~~~~~
--
trash-empty.c:49:1: warning: ‘trash_empty_clear_pending’ defined but not used [-Wunused-function]
   49 | trash_empty_clear_pending (gpointer user_data)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
--
netspeed.c:125:1: warning: ‘add_markup_size’ defined but not used [-Wunused-function]
  125 | add_markup_size(char **string, int size)
      | ^~~~~~~~~~~~~~~
--
cpufreq-applet.c:284:1: warning: ‘get_max_text_width’ defined but not used [-Wunused-function]
  284 | get_max_text_width (GtkWidget *widget,
      | ^~~~~~~~~~~~~~~~~~
```