### PR TITLE
Remove unused-variable warnings

### DIFF
--- a/accessx-status/applet.c
+++ b/accessx-status/applet.c
@@ -403,7 +403,6 @@ static GdkPixbuf* accessx_status_applet_get_glyph_pixbuf(GtkWidget* widget, GdkP
 static cairo_surface_t* accessx_status_applet_altgraph_image(AccessxStatusApplet *sapplet, GtkStateFlags state)
 {
 	GtkIconTheme *icon_theme;
-	cairo_t* cr;
 	GdkPixbuf* pixbuf;
 	GdkPixbuf* glyph_pixbuf;
 	GdkPixbuf* icon_base;

--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -274,12 +274,11 @@ static void
 menuitem_activated (GtkMenuItem *menuitem, charpick_data *curr_data)
 {
 	gchar *string;
-	MatePanelApplet *applet = MATE_PANEL_APPLET (curr_data->applet);
-	
+
 	string = g_object_get_data (G_OBJECT (menuitem), "string");
 	if (g_ascii_strcasecmp (curr_data->charlist, string) == 0)
 		return;
-	
+
 	curr_data->charlist = string;
 	build_table (curr_data);
 	if (g_settings_is_writable (curr_data->settings, "current-list"))
@@ -642,10 +641,9 @@ save_chartable (charpick_data *curr_data)
 static void
 get_chartable (charpick_data *curr_data)
 {
-	MatePanelApplet *applet = MATE_PANEL_APPLET (curr_data->applet);
 	gint i, n;
 	GList *value = NULL;
-	
+
 	value = mate_panel_applet_settings_get_glist (curr_data->settings, "chartable");
 	if (value) {
 		curr_data->chartable = value;
@@ -654,16 +652,13 @@ get_chartable (charpick_data *curr_data)
 		n = G_N_ELEMENTS (chartable);
 		for (i=0; i<n; i++) {
 			gchar *string;
-		
+
 			string = g_ucs4_to_utf8 (chartable[i], -1, NULL, NULL, NULL);
 			curr_data->chartable = g_list_append (curr_data->chartable, string);
-		
 		}
 		if ( ! g_settings_is_writable (curr_data->settings, "chartable"))
 			save_chartable (curr_data);
 	}
-	
-
 }
 
 static const GtkActionEntry charpick_applet_menu_actions [] = {

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -807,7 +807,6 @@ cpufreq_applet_setup (CPUFreqApplet *applet)
 	GtkActionGroup *action_group;
 	gchar          *ui_path;
         AtkObject      *atk_obj;
-        gchar          *prefs_key;
 	GSettings      *settings;
 
 	g_set_application_name  (_("CPU Frequency Scaling Monitor"));

--- a/mateweather/mateweather-dialog.c
+++ b/mateweather/mateweather-dialog.c
@@ -60,14 +60,14 @@ G_DEFINE_TYPE_WITH_PRIVATE (MateWeatherDialog, mateweather_dialog, GTK_TYPE_DIAL
 
 static void mateweather_dialog_save_geometry(MateWeatherDialog* dialog)
 {
+#if 0
 	GSettings* settings;
 	int w, h;
 
+	gtk_window_get_size (GTK_WINDOW (dialog), &w, &h);
+
 	settings = dialog->priv->applet->settings;
 
-	gtk_window_get_size(GTK_WINDOW(dialog), &w, &h);
-
-#if 0
 	/* FIXME those keys are not in org.mate.weather! */
 	g_settings_set_int (settings, "dialog-width", w);
 	g_settings_set_int (settings, "dialog-height", h);
@@ -76,12 +76,12 @@ static void mateweather_dialog_save_geometry(MateWeatherDialog* dialog)
 
 static void mateweather_dialog_load_geometry(MateWeatherDialog* dialog)
 {
+#if 0
 	GSettings* settings;
 	int w, h;
 
 	settings = dialog->priv->applet->settings;
 
-#if 0
 	/* FIXME those keys are not in org.mate.weather! */
 	w = g_settings_get_int (settings, "dialog-width");
 	h = g_settings_get_int (settings, "dialog-height");

--- a/mateweather/mateweather-pref.c
+++ b/mateweather/mateweather-pref.c
@@ -263,11 +263,9 @@ static gboolean compare_location(GtkTreeModel* model, GtkTreePath* path, GtkTree
 
 static void load_locations(MateWeatherPref* pref)
 {
-	MateWeatherApplet* gw_applet = pref->priv->applet;
 	GtkTreeView* tree = GTK_TREE_VIEW(pref->priv->tree);
 	GtkTreeViewColumn* column;
 	GtkCellRenderer* cell_renderer;
-	WeatherLocation* current_location;
 
 	/* Add a column for the locations */
 	cell_renderer = gtk_cell_renderer_text_new();

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -296,8 +296,6 @@ GetSwap (int Maximum, int data [2], LoadGraph *g)
 void
 GetLoadAvg (int Maximum, int data [2], LoadGraph *g)
 {
-    float used;
-
     glibtop_loadavg loadavg;
     glibtop_get_loadavg (&loadavg);
 
@@ -380,7 +378,6 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
 
     for(i = 0; i < netlist.number; ++i)
     {
-        int index;
         glibtop_netload netload;
 
         glibtop_get_netload(&netload, devices[i]);
@@ -419,7 +416,6 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
     else
     {
         int delta[COUNT_TYPES];
-        int max;
         int total = 0;
 
         for (i = 0; i < COUNT_TYPES; i++)

--- a/multiload/load-graph.c
+++ b/multiload/load-graph.c
@@ -106,7 +106,6 @@ load_graph_draw (LoadGraph *g)
     }
     //printf("max = %d ", maxnet);
     guint level = 0;
-    GdkRGBA grid_color;
     if (maxnet > g->net_threshold3) {
       g->net_threshold = g->net_threshold3;
       level = 3;

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -580,7 +580,6 @@ search_for_up_if(MateNetspeedApplet *applet)
 {
 	const gchar *default_route;
 	GList *devices, *tmp;
-	DevInfo info;
 
 	default_route = get_default_route();
 
@@ -1569,7 +1568,6 @@ mate_netspeed_applet_factory(MatePanelApplet *applet_widget, const gchar *iid, g
 {
 	MateNetspeedApplet *applet;
 	int i;
-	char* menu_string;
 	GtkIconTheme *icon_theme;
 	GtkWidget *spacer, *spacer_box;
 


### PR DESCRIPTION
```
charpick.c:277:19: warning: unused variable ‘applet’ [-Wunused-variable]
  277 |  MatePanelApplet *applet = MATE_PANEL_APPLET (curr_data->applet);
      |                   ^~~~~~
--
charpick.c:645:19: warning: unused variable ‘applet’ [-Wunused-variable]
  645 |  MatePanelApplet *applet = MATE_PANEL_APPLET (curr_data->applet);
      |                   ^~~~~~
--
linux-proc.c:299:11: warning: unused variable ‘used’ [-Wunused-variable]
  299 |     float used;
      |           ^~~~
--
linux-proc.c:383:13: warning: unused variable ‘index’ [-Wunused-variable]
  383 |         int index;
      |             ^~~~~
linux-proc.c:422:13: warning: unused variable ‘max’ [-Wunused-variable]
  422 |         int max;
      |             ^~~
--
load-graph.c:109:13: warning: unused variable ‘grid_color’ [-Wunused-variable]
  109 |     GdkRGBA grid_color;
      |             ^~~~~~~~~~
--
netspeed.c:583:10: warning: unused variable ‘info’ [-Wunused-variable]
  583 |  DevInfo info;
      |          ^~~~
--
netspeed.c:1572:8: warning: unused variable ‘menu_string’ [-Wunused-variable]
 1572 |  char* menu_string;
      |        ^~~~~~~~~~~
--
mateweather-pref.c:270:19: warning: unused variable ‘current_location’ [-Wunused-variable]
  270 |  WeatherLocation* current_location;
      |                   ^~~~~~~~~~~~~~~~
mateweather-pref.c:266:21: warning: unused variable ‘gw_applet’ [-Wunused-variable]
  266 |  MateWeatherApplet* gw_applet = pref->priv->applet;
      |                     ^~~~~~~~~
--
mateweather-dialog.c:80:9: warning: unused variable ‘h’ [-Wunused-variable]
   80 |  int w, h;
      |         ^
mateweather-dialog.c:80:6: warning: unused variable ‘w’ [-Wunused-variable]
   80 |  int w, h;
      |      ^
--
battstat-upower.c:97:11: warning: unused variable ‘gerror’ [-Wunused-variable]
   97 |   GError *gerror;
      |           ^~~~~~
battstat-upower.c:96:17: warning: unused variable ‘cancellable’ [-Wunused-variable]
   96 |   GCancellable *cancellable = g_cancellable_new();
      |                 ^~~~~~~~~~~
battstat-upower.c:83:10: warning: unused variable ‘num’ [-Wunused-variable]
   83 |   int i, num;
      |          ^~~
battstat-upower.c:83:7: warning: unused variable ‘i’ [-Wunused-variable]
   83 |   int i, num;
      |       ^
battstat-upower.c:82:9: warning: unused variable ‘error_str’ [-Wunused-variable]
   82 |   char *error_str;
      |         ^~~~~~~~~
--
battstat-upower.c:203:11: warning: unused variable ‘item’ [-Wunused-variable]
  203 |   GSList *item;
      |           ^~~~
--
applet.c:406:11: warning: unused variable ‘cr’ [-Wunused-variable]
  406 |  cairo_t* cr;
      |           ^~
--
cpufreq-applet.c:810:25: warning: unused variable ‘prefs_key’ [-Wunused-variable]
  810 |         gchar          *prefs_key;
      |                         ^~~~~~~~~
```