### PR TITLE
stickynotes: Remove strict-prototypes warning

### DIFF
--- a/stickynotes/stickynotes_applet_callbacks.c
+++ b/stickynotes/stickynotes_applet_callbacks.c
@@ -77,7 +77,7 @@ stickynote_show_notes (gboolean visible)
 }
 
 static void
-stickynote_toggle_notes_visible ()
+stickynote_toggle_notes_visible (void)
 {
     stickynote_show_notes(!stickynotes->visible);
 }


### PR DESCRIPTION
```
stickynotes_applet_callbacks.c:80:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   80 | stickynote_toggle_notes_visible ()
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```