### PR TITLE
multiload: fix wrong memory graphs

### DIFF
--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -260,10 +260,17 @@ GetMemory (int Maximum, int data [5], LoadGraph *g)
 
     g_return_if_fail ((mem.flags & needed_mem_flags) == needed_mem_flags);
 
+#ifdef __linux__
     user    = rint (Maximum * (float)(mem.user - mem.shared) / (float)mem.total);
     shared  = rint (Maximum * (float)mem.shared / (float)mem.total);
     buffer  = rint (Maximum * (float)mem.buffer / (float)mem.total);
     cached  = rint (Maximum * (float)(mem.total - mem.user - mem.buffer - mem.free) / (float)mem.total);
+#else
+    user    = rint (Maximum * (float)mem.user   / (float)mem.total);
+    shared  = rint (Maximum * (float)mem.shared / (float)mem.total);
+    buffer  = rint (Maximum * (float)mem.buffer / (float)mem.total);
+    cached  = rint (Maximum * (float)mem.cached / (float)mem.total);
+#endif
 
     data [0] = user;
     data [1] = shared;

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -260,10 +260,10 @@ GetMemory (int Maximum, int data [5], LoadGraph *g)
 
     g_return_if_fail ((mem.flags & needed_mem_flags) == needed_mem_flags);
 
-    user    = rint (Maximum * (float)mem.user / (float)mem.total);
+    user    = rint (Maximum * (float)(mem.user - mem.shared) / (float)mem.total);
     shared  = rint (Maximum * (float)mem.shared / (float)mem.total);
     buffer  = rint (Maximum * (float)mem.buffer / (float)mem.total);
-    cached = rint (Maximum * (float)mem.cached / (float)mem.total);
+    cached  = rint (Maximum * (float)(mem.total - mem.user - mem.buffer - mem.free) / (float)mem.total);
 
     data [0] = user;
     data [1] = shared;


### PR DESCRIPTION
Shared memory is now part of cached memory and user memory. Currently, if you have 25% of memory used by programs, 50% as tmpfs, and 25% as cache, the applet will display:
- 75% user
- 50% shared
- 75% cache

...and that's well above 100%, so it doesn't even fit into the graph.

Memory should be calculated differently now:
- Shared memory is almost only tmpfs now; add it to the tooltip with "...used as tmpfs"
- Cache: subtract shared from it, it's displayed separately
- User: actually, glibtop calculates "user" as "MemTotal - MemAvailable", so it's completely useless. If used as it is, the graph will still total over 100%. Better calculate it as "total - buffers - cache (which already includes shared)".