### PR TITLE
multiload: display disk read/write size in tooltip text

### DIFF
--- a/multiload/global.h
+++ b/multiload/global.h
@@ -53,6 +53,8 @@ struct _LoadGraph {
     guint net_threshold1;
     guint net_threshold2;
     guint net_threshold3;
+    guint64 disk_readdiff;
+    guint64 disk_writediff;
 
     gboolean visible;
     gboolean tooltip_update;

--- a/multiload/main.c
+++ b/multiload/main.c
@@ -321,6 +321,18 @@ multiload_applet_tooltip_update(LoadGraph *g)
 					       name, tx_in, tx_out);
 		g_free(tx_in);
 		g_free(tx_out);
+	} else if (!strcmp(g->name, "diskload")) {
+		char *disk_read, *disk_write;
+		disk_read = g_format_size (g->disk_readdiff);
+		disk_write = g_format_size (g->disk_writediff);
+		tooltip_text = g_strdup_printf(_("%s:\n"
+		                                 "Read %s\n"
+		                                 "Write %s"),
+		                               name,
+		                               disk_read,
+		                               disk_write);
+		g_free (disk_read);
+		g_free (disk_write);
 	} else {
 		const char *msg;
 		guint i, total_used, percent;


### PR DESCRIPTION
Write test: 1 GiB
```
$ sync; dd if=/dev/zero of=tempfile bs=1M count=1024; sync
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 48.7581 s, 22.0 MB/s
```
Read test: 1 GiB
```
$ sudo /sbin/sysctl -w vm.drop_caches=3
$ dd if=tempfile of=/dev/null bs=1M count=1024
vm.drop_caches = 3
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.95827 s, 363 MB/s
```
Clear:
```
$ rm tempfile
```