### PR TITLE
Remove unused variable warning reported by cppcheck

### DIFF
--- a/battstat/acpi-freebsd.c
+++ b/battstat/acpi-freebsd.c
@@ -141,7 +141,6 @@ acpi_freebsd_read(struct apm_info *apminfo, struct acpi_info * acpiinfo)
 {
   int time;
   int life;
-  int acline;
   int state;
   size_t len;
   int rate;

--- a/battstat/power-management.c
+++ b/battstat/power-management.c
@@ -434,12 +434,12 @@ power_management_getinfo( BatteryStatus *status )
 const char *
 power_management_initialise (void (*callback) (void))
 {
-  char *err;
 #ifdef __linux__
   struct stat statbuf;
-#endif
-
+#endif /* __linux__ */
 #ifdef HAVE_UPOWER
+  char *err;
+
   err = battstat_upower_initialise (callback);
 
   if( err == NULL ) /* UPOWER is up */
@@ -451,8 +451,8 @@ power_management_initialise (void (*callback) (void))
   else
     /* fallback to legacy methods */
     g_free( err );
-#endif
-    
+#endif /* HAVE_UPOWER */
+
 #ifdef __linux__
 
   if (acpi_linux_init(&acpiinfo)) {


### PR DESCRIPTION
```
$ cppcheck --enable=all . 2> err.txt
$ grep unusedVariable err.txt 
battstat/acpi-freebsd.c:144:7: style: Unused variable: acline [unusedVariable]
battstat/power-management.c:437:9: style: Unused variable: err [unusedVariable]
```