### PR TITLE
Remove warning about assigned value is never used reported by cppcheck

### DIFF
--- a/cpufreq/src/cpufreq-selector.c
+++ b/cpufreq/src/cpufreq-selector.c
@@ -44,9 +44,9 @@ G_DEFINE_TYPE (CPUFreqSelector, cpufreq_selector, G_TYPE_OBJECT)
 static void
 cpufreq_selector_finalize (GObject *object)
 {
+#ifdef HAVE_POLKIT
 	CPUFreqSelector *selector = CPUFREQ_SELECTOR (object);
 
-#ifdef HAVE_POLKIT
 	g_clear_object (&selector->proxy);
 	g_clear_object (&selector->system_bus);
 #endif /* HAVE_POLKIT */

--- a/mateweather/mateweather-dialog.c
+++ b/mateweather/mateweather-dialog.c
@@ -115,7 +115,7 @@ static void link_cb(GtkButton* button, gpointer data)
 static gchar* replace_multiple_new_lines(gchar* s)
 {
 	gchar *prev_s = s;
-	gint count = 0;
+	gint count;
 	gint i;
 
 	if (s == NULL) {

--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -416,7 +416,6 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
     else
     {
         int delta[COUNT_TYPES];
-        int total = 0;
 
         for (i = 0; i < COUNT_TYPES; i++)
         {
@@ -425,10 +424,7 @@ GetNet (int Maximum, int data [4], LoadGraph *g)
                 delta[i] = (present[i] - past[i]);
             else
                 delta[i] = 0;
-            total += delta[i];
         }
-
-        //max = autoscaler_get_max(&scaler, total);
 
         for (i = 0; i < COUNT_TYPES; i++)
             data[i]   = delta[i];

--- a/multiload/load-graph.c
+++ b/multiload/load-graph.c
@@ -93,7 +93,7 @@ load_graph_draw (LoadGraph *g)
   {
     guint maxnet = 1;
     gint segments = 1;
-    gint combined = 0;
+    gint combined;
     for (i = 0; i < g->draw_width; i++)
     {
       g->pos [i] = g->draw_height - 1;
@@ -154,7 +154,7 @@ load_graph_draw (LoadGraph *g)
 
     /* draw grid lines if needed */
     gdk_cairo_set_source_rgba (cr, &(g->colors [4]));
-    double spacing = 0;
+    double spacing;
     for (k = 0; k < segments -1; k++)
     {
       spacing = ((double) g->draw_height/segments) * (k+1);
@@ -209,7 +209,7 @@ load_graph_draw (LoadGraph *g)
     /* draw grid lines in Load graph if needed */
     gdk_cairo_set_source_rgba (cr, &(g->colors [2]));
 
-    double spacing = 0;
+    double spacing;
     for (k = 0; k < load - 1; k++)
     {
       spacing = ((double) g->draw_height/load) * (k+1);


### PR DESCRIPTION
```
$ cppcheck --enable=all . 2> err.txt
$ grep unreadVariable err.txt 
cpufreq/src/cpufreq-selector.c:47:28: style: Variable 'selector' is assigned a value that is never used. [unreadVariable]
mateweather/mateweather-dialog.c:118:13: style: Variable 'count' is assigned a value that is never used. [unreadVariable]
multiload/linux-proc.c:419:19: style: Variable 'total' is assigned a value that is never used. [unreadVariable]
multiload/linux-proc.c:428:19: style: Variable 'total' is assigned a value that is never used. [unreadVariable]
multiload/load-graph.c:96:19: style: Variable 'combined' is assigned a value that is never used. [unreadVariable]
multiload/load-graph.c:157:20: style: Variable 'spacing' is assigned a value that is never used. [unreadVariable]
multiload/load-graph.c:212:20: style: Variable 'spacing' is assigned a value that is never used. [unreadVariable]
```