### PR TITLE
battstat: warning about boolean algebra reported by cppcheck

### DIFF
--- a/battstat/acpi-freebsd.c
+++ b/battstat/acpi-freebsd.c
@@ -197,7 +197,7 @@ acpi_freebsd_read(struct apm_info *apminfo, struct acpi_info * acpiinfo)
   if (!charging) {
     apminfo->ai_batt_time = time;
   }
-  else if (charging && rate > 0) {
+  else if (rate > 0) {
     apminfo->ai_batt_time = (int) ((acpiinfo->max_capacity-remain)/(float)rate);
   }
   else


### PR DESCRIPTION
```
$ cppcheck --enable=all . 2> err.txt
$ grep knownConditionTrueFalse err.txt 
battstat/acpi-freebsd.c:200:12: style: Condition 'charging' is always true [knownConditionTrueFalse]
```