### PR TITLE
Remove -Wtype-limits warnings

### DIFF
--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -918,15 +918,15 @@ load_preferences(ProgressData *battstat)
   if (DEBUG) g_print("load_preferences()\n");
 
   battstat->red_val = g_settings_get_int (settings, "red-value");
-  battstat->red_val = CLAMP (battstat->red_val, 0, 100);
+  battstat->red_val = MIN (battstat->red_val, 100);
   battstat->red_value_is_time = g_settings_get_boolean (settings, "red-value-is-time");
 
   /* automatically calculate orangle and yellow values from the red value */
   battstat->orange_val = battstat->red_val * ORANGE_MULTIPLIER;
-  battstat->orange_val = CLAMP (battstat->orange_val, 0, 100);
+  battstat->orange_val = MIN (battstat->orange_val, 100);
 
   battstat->yellow_val = battstat->red_val * YELLOW_MULTIPLIER;
-  battstat->yellow_val = CLAMP (battstat->yellow_val, 0, 100);
+  battstat->yellow_val = MIN (battstat->yellow_val, 100);
 
   battstat->lowbattnotification = g_settings_get_boolean (settings, "low-battery-notification");
   battstat->fullbattnot = g_settings_get_boolean (settings, "full-battery-notification");

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -380,7 +380,7 @@ update_quality_icon(MateNetspeedApplet *applet)
 
 	q = (applet->devinfo->qual);
 	q /= 25;
-	q = CLAMP(q, 0, 3); /* q out of range would crash when accessing qual_surfaces[q] */
+	q = MIN (q, 3); /* q out of range would crash when accessing qual_surfaces[q] */
 	gtk_image_set_from_surface (GTK_IMAGE(applet->qual_pix), applet->qual_surfaces[q]);
 }
 


### PR DESCRIPTION
```
netspeed.c: In function 'update_quality_icon':
/usr/include/glib-2.0/glib/gmacros.h:813:63: warning: comparison of unsigned expression in '< 0' is always false [-Wtype-limits]
  813 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
netspeed.c:345:6: note: in expansion of macro 'CLAMP'
  345 |  q = CLAMP(q, 0, 3); /* q out of range would crash when accessing qual_surfaces[q] */
      |      ^~~~~

--
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
netspeed.c:383:6: note: in expansion of macro ‘CLAMP’
  383 |  q = CLAMP(q, 0, 3); /* q out of range would crash when accessing qual_surfaces[q] */
      |      ^~~~~

--
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
battstat_applet.c:923:23: note: in expansion of macro ‘CLAMP’
  923 |   battstat->red_val = CLAMP (battstat->red_val, 0, 100);
      |                       ^~~~~
--
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
battstat_applet.c:928:26: note: in expansion of macro ‘CLAMP’
  928 |   battstat->orange_val = CLAMP (battstat->orange_val, 0, 100);
      |                          ^~~~~
--
/usr/include/glib-2.0/glib/gmacros.h:811:63: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
  811 | #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
      |                                                               ^
battstat_applet.c:931:26: note: in expansion of macro ‘CLAMP’
  931 |   battstat->yellow_val = CLAMP (battstat->yellow_val, 0, 100);
      |                          ^~~~~
```