### PR TITLE
stickynotes: Fix -Wformat-nonliteral warning

### DIFF
--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -399,17 +399,21 @@ void stickynote_set_title(StickyNote *note, const gchar *title)
 {
 	/* If title is NULL, use the current date as the title. */
 	if (!title) {
-		gchar *date_title, *tmp;
-		gchar *date_format = g_settings_get_string (stickynotes->settings, "date-format");
+		GDateTime *now;
+		gchar *date_title;
+		gchar *date_format;
+
+		date_format = g_settings_get_string (stickynotes->settings, "date-format");
 		if (!date_format)
 			date_format = g_strdup ("%x");
-		tmp = get_current_date (date_format);
-		date_title = g_locale_to_utf8 (tmp, -1, NULL, NULL, NULL);
+
+		now = g_date_time_new_now_local ();
+		date_title = g_date_time_format (now, date_format);
 
 		gtk_window_set_title(GTK_WINDOW(note->w_window), date_title);
 		gtk_label_set_text(GTK_LABEL (note->w_title), date_title);
 
-		g_free (tmp);
+		g_date_time_unref (now);
 		g_free(date_title);
 		g_free(date_format);
 	}

--- a/stickynotes/util.c
+++ b/stickynotes/util.c
@@ -20,33 +20,11 @@
 #include <config.h>
 #include "util.h"
 
-#include <time.h>
-
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
-
-/* Returns the current date in a customizable form, the default
- * looks like this: "Nov 30, '78" */
-gchar * get_current_date(const gchar *format)
-{
-  	time_t clock = time(NULL);
-  	struct tm *current = localtime(&clock);
-
-	gint date_length = 10;
-  	gchar *date = g_new(gchar, date_length);
-  	
-	do
-	{
-		date_length += 5;
-		date = (gchar *) g_renew(gchar, date, date_length);
-	}
-  	while(strftime(date, date_length, format, current) == 0);
-	
-  	return date;
-}
 
 static Atom
 xstuff_atom_get (const char *atom_name)

--- a/stickynotes/util.h
+++ b/stickynotes/util.h
@@ -23,7 +23,6 @@
 #include <glib.h>
 #include <gtk/gtk.h>
 
-gchar * get_current_date(const gchar *format);
 void	xstuff_change_workspace (GtkWindow *window,
 			         int        new_space);
 int	xstuff_get_current_workspace (GtkWindow *window);


### PR DESCRIPTION
```
util.c:46:4: warning: format not a string literal, format string not checked [-Wformat-nonliteral]
   46 |    while(strftime(date, date_length, format, current) == 0);
      |    ^~~~~
--
```
In contrast to `strftime`, [g_date_time_format](https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format) always produces a UTF-8 string.
