### PR TITLE
battstat: invalidScanfArgType_int cppcheck warnings (/proc/apm)

### DIFF
--- a/battstat/apmlib/apm.h
+++ b/battstat/apmlib/apm.h
@@ -41,10 +41,10 @@ typedef struct apm_info
     const char driver_version[10];
     int apm_version_major;
     int apm_version_minor;
-    int apm_flags;
-    int ac_line_status;
-    int battery_status;
-    int battery_flags;
+    unsigned short apm_flags;
+    unsigned short ac_line_status;
+    unsigned short battery_status;
+    unsigned short battery_flags;
     int battery_percentage;
     int battery_time;
     int using_minutes;

--- a/battstat/apmlib/apmlib.c
+++ b/battstat/apmlib/apmlib.c
@@ -68,7 +68,7 @@ int apm_read(apm_info * i)
     /* Should check for other driver versions; driver 1.9 (and some
      * others) uses this format, which doesn't expose # batteries.
      */
-    sscanf(buffer, "%s %d.%d %x %x %x %x %d%% %d %s\n",
+    sscanf(buffer, "%s %d.%d %hx %hx %hx %hx %d%% %d %s\n",
 	   (char *) i->driver_version,
 	   &i->apm_version_major,
 	   &i->apm_version_minor,
@@ -102,7 +102,7 @@ int apm_read(apm_info * i)
 	if (fgets(buffer, sizeof(buffer) - 1, str) == NULL)
 	    printf("fgets error\n");
 
-	sscanf(buffer, "Flags: 0x%02x", &i->apm_flags);
+	sscanf(buffer, "Flags: 0x%02hx", &i->apm_flags);
 	if (i->apm_flags & APM_32_BIT_SUPPORT)
 	{
 	    if (fgets(buffer, sizeof(buffer) - 1, str) == NULL)
@@ -142,7 +142,7 @@ int apm_read(apm_info * i)
 		    if (fgets(buffer, sizeof(buffer) - 1, str) == NULL)
 			printf("fgets error\n");
 
-		    sscanf(buffer, "Battery flag: 0x%02x", &i->battery_flags);
+		    sscanf(buffer, "Battery flag: 0x%02hx", &i->battery_flags);
 
 		    if (fgets(buffer, sizeof(buffer) - 1, str) == NULL)
 			printf("fgets error\n");


### PR DESCRIPTION
`ac_line_status`, `battery_status`, `battery_flag`, `apm_info.bios.flags` are `unsigned short`.

arch/x86/kernel/apm_32.c
```C
static int proc_apm_show(struct seq_file *m, void *v)
{
        unsigned short  bx;
        unsigned short  cx;
        unsigned short  dx;
        int             error;
        unsigned short  ac_line_status = 0xff;
        unsigned short  battery_status = 0xff;
        unsigned short  battery_flag   = 0xff;
        int             percentage     = -1;
        int             time_units     = -1;
        char            *units         = "?";

        if ((num_online_cpus() == 1) &&
            !(error = apm_get_power_status(&bx, &cx, &dx))) {
                ac_line_status = (bx >> 8) & 0xff;
                battery_status = bx & 0xff;
                if ((cx & 0xff) != 0xff)
                        percentage = cx & 0xff;

                if (apm_info.connection_version > 0x100) {
                        battery_flag = (cx >> 8) & 0xff;
                        if (dx != 0xffff) {
                                units = (dx & 0x8000) ? "min" : "sec";
                                time_units = dx & 0x7fff;
                        }
                }
        }
	/* Arguments, with symbols from linux/apm_bios.h.  Information is
           from the Get Power Status (0x0a) call unless otherwise noted.

           0) Linux driver version (this will change if format changes)
           1) APM BIOS Version.  Usually 1.0, 1.1 or 1.2.
           2) APM flags from APM Installation Check (0x00):
              bit 0: APM_16_BIT_SUPPORT
              bit 1: APM_32_BIT_SUPPORT
              bit 2: APM_IDLE_SLOWS_CLOCK
              bit 3: APM_BIOS_DISABLED
              bit 4: APM_BIOS_DISENGAGED
           3) AC line status
              0x00: Off-line
              0x01: On-line
              0x02: On backup power (BIOS >= 1.1 only)
              0xff: Unknown
           4) Battery status
              0x00: High
              0x01: Low
              0x02: Critical
              0x03: Charging
              0x04: Selected battery not present (BIOS >= 1.2 only)
              0xff: Unknown
           5) Battery flag
              bit 0: High
              bit 1: Low
              bit 2: Critical
              bit 3: Charging
              bit 7: No system battery
              0xff: Unknown
           6) Remaining battery life (percentage of charge):
              0-100: valid
              -1: Unknown
           7) Remaining battery life (time units):
              Number of remaining minutes or seconds
              -1: Unknown
           8) min = minutes; sec = seconds */

        seq_printf(m, "%s %d.%d 0x%02x 0x%02x 0x%02x 0x%02x %d%% %d %s\n",
                   driver_version,
                   (apm_info.bios.version >> 8) & 0xff,
                   apm_info.bios.version & 0xff,
                   apm_info.bios.flags,
                   ac_line_status,
                   battery_status,
                   battery_flag,
                   percentage,
                   time_units,
                   units);
        return 0;
}
```
include/uapi/linux/apm_bios.h
```C
struct apm_bios_info {
        __u16   version;
        __u16   cseg;
        __u32   offset;
        __u16   cseg_16;
        __u16   dseg;
        __u16   flags;
        __u16   cseg_len;
        __u16   cseg_16_len;
        __u16   dseg_len;
};
```
Test:
```
/* gcc `pkg-config --libs --cflags glib-2.0` test-apm.c -o test-apm */
#include <stdio.h>
#include <string.h>
#include <glib.h>

typedef struct apm_info
{
    const char driver_version[10];
    int apm_version_major;
    int apm_version_minor;
    unsigned short apm_flags;
    unsigned short ac_line_status;
    unsigned short battery_status;
    unsigned short battery_flags;
    int battery_percentage;
    int battery_time;
    int using_minutes;
}
apm_info;


int main() {
    const char *buffer        = "1.16 1.2 0x03 0x00 0x00 0x01 99% 1792 min";
    const char *ac_buffer     = "1.16 1.2 0x03 0x01 0x03 0x09 100% -1 ?";
    const char *nobatt_buffer = "1.16 1.2 0x07 0x01 0xff 0x80 -1% -1 ?";
    char units[10];

    apm_info *i = g_new0 (apm_info, 1);

    /* discharging */
    sscanf(buffer, "%s %d.%d %hx %hx %hx %hx %d%% %d %s\n",
	   (char *) i->driver_version,
	   &i->apm_version_major,
	   &i->apm_version_minor,
	   &i->apm_flags,
	   &i->ac_line_status,
	   &i->battery_status,
	   &i->battery_flags,
	   &i->battery_percentage,
	   &i->battery_time,
	   units);
    printf ("%s\n", buffer);
    printf("%s %d.%d 0x%02hx 0x%02hx 0x%02hx 0x%02hx %d%% %d %s\n",
           i->driver_version,
           i->apm_version_major,
           i->apm_version_minor,
           i->apm_flags,
           i->ac_line_status,
           i->battery_status,
           i->battery_flags,
           i->battery_percentage,
           i->battery_time,
           units);
    printf ("--\n");

    /* ac power */
    sscanf(ac_buffer, "%s %d.%d %hx %hx %hx %hx %d%% %d %s\n",
           (char *) i->driver_version,
           &i->apm_version_major,
           &i->apm_version_minor,
           &i->apm_flags,
           &i->ac_line_status,
           &i->battery_status,
           &i->battery_flags,
           &i->battery_percentage,
           &i->battery_time,
           units);
    printf ("%s\n", ac_buffer);
    printf("%s %d.%d 0x%02hx 0x%02hx 0x%02hx 0x%02hx %d%% %d %s\n",
           i->driver_version,
           i->apm_version_major,
           i->apm_version_minor,
           i->apm_flags,
           i->ac_line_status,
           i->battery_status,
           i->battery_flags,
           i->battery_percentage,
           i->battery_time,
           units);
    printf ("--\n");

    /* no battery:
     * $ apm -v
     * APM BIOS 1.2 (kernel driver 1.16ac)
     * AC on-line, no system battery
     */
    sscanf(nobatt_buffer, "%s %d.%d %hx %hx %hx %hx %d%% %d %s\n",
           (char *) i->driver_version,
           &i->apm_version_major,
           &i->apm_version_minor,
           &i->apm_flags,
           &i->ac_line_status,
           &i->battery_status,
           &i->battery_flags,
           &i->battery_percentage,
           &i->battery_time,
           units);
    printf ("%s\n", nobatt_buffer);
    printf("%s %d.%d 0x%02hx 0x%02hx 0x%02hx 0x%02hx %d%% %d %s\n",
           i->driver_version,
           i->apm_version_major,
           i->apm_version_minor,
           i->apm_flags,
           i->ac_line_status,
           i->battery_status,
           i->battery_flags,
           i->battery_percentage,
           i->battery_time,
           units);

    g_free (i);

    return 0;
}
```