### PR TITLE
multiload: do not count shared memory twice on Linux

### DIFF
--- a/multiload/linux-proc.c
+++ b/multiload/linux-proc.c
@@ -207,6 +207,18 @@ GetDiskLoad (int        Maximum,
     data [diskload_free]  = Maximum - (data [0] + data[1]);
 }
 
+/* GNU/Linux:
+ *   aux [memload_user]   = (mem.total - mem.free) - (mem.cached + mem.buffer)
+ *   aux [memload_shared] = mem.shared;
+ *   aux [memload_cached] = mem.cached - mem.shared;
+ *   aux [memload_buffer] = mem.buffer;
+ *
+ * Other operating systems:
+ *   aux [memload_user]   = mem.user;
+ *   aux [memload_shared] = mem.shared;
+ *   aux [memload_cached] = mem.cached;
+ *   aux [memload_buffer] = mem.buffer;
+ */
 void
 GetMemory (int        Maximum,
            int        data [memload_n],
@@ -222,15 +234,15 @@ GetMemory (int        Maximum,
 
     g_return_if_fail ((mem.flags & needed_mem_flags) == needed_mem_flags);
 
-    multiload = g->multiload;
-    multiload->memload_user  = mem.user;
-    multiload->memload_cache = mem.cached;
-    multiload->memload_total = mem.total;
-
+#ifndef __linux__
     aux [memload_user]   = mem.user;
+    aux [memload_cached] = mem.cached;
+#else
+    aux [memload_user]   = mem.total - mem.free - mem.buffer - mem.cached;;
+    aux [memload_cached] = mem.cached - mem.shared;
+#endif /* __linux__ */
     aux [memload_shared] = mem.shared;
     aux [memload_buffer] = mem.buffer;
-    aux [memload_cached] = mem.cached;
 
     for (i = 0; i < memload_free; i++) {
         current_scaled = rint ((float)(aux [i] * Maximum) / (float)mem.total);
@@ -241,6 +253,11 @@ GetMemory (int        Maximum,
         data [i] = current_scaled;
     }
     data [memload_free] = MAX (Maximum - used_scaled, 0);
+
+    multiload = g->multiload;
+    multiload->memload_user  = aux [memload_user];
+    multiload->memload_cache = cache;
+    multiload->memload_total = mem.total;
 }
 
 void


### PR DESCRIPTION
Restore user memory value which was updated on libgtop 2.32,
since the new value cannot be used to display multiple memory
areas.

https://github.com/GNOME/libgtop/commit/0580b2fb2ca8fdde2031c8aba991bafac64d8dbd