### PR TITLE
cpufreq: -1 indicates error obtaining max frequency

### DIFF
--- a/cpufreq/src/cpufreq-monitor.c
+++ b/cpufreq/src/cpufreq-monitor.c
@@ -125,7 +125,7 @@ cpufreq_monitor_class_init (CPUFreqMonitorClass *klass)
                                          g_param_spec_int ("max-frequency",
                                                            "MaxFrequency",
                                                            "The max cpu frequency",
-                                                           0,
+                                                           -1,
                                                            G_MAXINT,
                                                            0,
                                                            G_PARAM_READWRITE));


### PR DESCRIPTION
Test: Add cpufreq-monitor-applet on a VM.

https://github.com/mate-desktop/mate-applets/blob/ca4a3b697836a99590c1e81a0b263588609b647c/cpufreq/src/cpufreq-monitor-libcpufreq.c#L73-L80