### PR TITLE
geyes: do not use dirent.h nor PATH_MAX

### DIFF
--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -206,7 +206,8 @@ properties_load (EyesApplet *eyes_applet)
     gchar *theme_path = NULL;
     gboolean result;
 
-    theme_path = g_settings_get_string (eyes_applet->settings, "theme-path");
+    theme_path = g_settings_get_string (eyes_applet->settings,
+                                        GEYES_SETTINGS_THEME_PATH_KEY);
 
     if (theme_path == NULL)
         theme_path = g_strdup (GEYES_THEMES_DIR "Default-tiny");
@@ -287,7 +288,7 @@ create_eyes (MatePanelApplet *applet)
     eyes_applet->vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     eyes_applet->settings =
         mate_panel_applet_settings_new (applet,
-                                        "org.mate.panel.applet.geyes");
+                                        GEYES_SETTINGS_SCHEMA);
     gtk_container_add (GTK_CONTAINER (applet), eyes_applet->vbox);
     return eyes_applet;
 }

--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -358,8 +358,7 @@ help_cb (GtkAction  *action,
         gtk_window_set_screen (GTK_WINDOW (dialog),
                                gtk_widget_get_screen (GTK_WIDGET (eyes_applet->applet)));
         gtk_widget_show (dialog);
-        g_error_free (error);
-        error = NULL;
+        g_clear_error (&error);
     }
 }
 

--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -314,20 +314,16 @@ destroy_cb (GObject    *object,
         g_object_unref (eyes_applet->pupil_image);
     eyes_applet->pupil_image = NULL;
 
-    if (eyes_applet->theme_dir)
-        g_free (eyes_applet->theme_dir);
+    g_free (eyes_applet->theme_dir);
     eyes_applet->theme_dir = NULL;
 
-    if (eyes_applet->theme_name)
-        g_free (eyes_applet->theme_name);
+    g_free (eyes_applet->theme_name);
     eyes_applet->theme_name = NULL;
 
-    if (eyes_applet->eye_filename)
-        g_free (eyes_applet->eye_filename);
+    g_free (eyes_applet->eye_filename);
     eyes_applet->eye_filename = NULL;
 
-    if (eyes_applet->pupil_filename)
-        g_free (eyes_applet->pupil_filename);
+    g_free (eyes_applet->pupil_filename);
     eyes_applet->pupil_filename = NULL;
 
     if (eyes_applet->prop_box.pbox)

--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -200,23 +200,21 @@ about_cb (GtkAction  *action,
                            NULL);
 }
 
-static int
+static gboolean
 properties_load (EyesApplet *eyes_applet)
 {
     gchar *theme_path = NULL;
+    gboolean result;
 
     theme_path = g_settings_get_string (eyes_applet->settings, "theme-path");
 
     if (theme_path == NULL)
         theme_path = g_strdup (GEYES_THEMES_DIR "Default-tiny");
 
-    if (load_theme (eyes_applet, theme_path) == FALSE) {
-        g_free (theme_path);
-        return FALSE;
-    }
-
+    result = load_theme (eyes_applet, theme_path);
     g_free (theme_path);
-    return TRUE;
+
+    return result;
 }
 
 void
@@ -396,6 +394,7 @@ geyes_applet_fill (MatePanelApplet *applet)
 {
     EyesApplet *eyes_applet;
     GtkActionGroup *action_group;
+    gboolean result;
 
     g_set_application_name (_("Eyes"));
     gtk_window_set_default_icon_name ("mate-eyes-applet");
@@ -441,12 +440,10 @@ geyes_applet_fill (MatePanelApplet *applet)
     /* setup here and not in create eyes so the destroy signal is set so
      * that when there is an error within loading the theme
      * we can emit this signal */
-    if (properties_load (eyes_applet) == FALSE)
-        return FALSE;
+    if ((result = properties_load (eyes_applet)) == TRUE)
+        setup_eyes (eyes_applet);
 
-    setup_eyes (eyes_applet);
-
-    return TRUE;
+    return result;
 }
 
 static gboolean

--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -29,436 +29,451 @@
 static gfloat
 gtk_align_to_gfloat (GtkAlign align)
 {
-	switch (align) {
-		case GTK_ALIGN_START:
-			return 0.0;
-		case GTK_ALIGN_END:
-			return 1.0;
-		case GTK_ALIGN_CENTER:
-		case GTK_ALIGN_FILL:
-			return 0.5;
-		default:
-			return 0.0;
-	}
+    switch (align) {
+        case GTK_ALIGN_START:
+            return 0.0;
+        case GTK_ALIGN_END:
+            return 1.0;
+        case GTK_ALIGN_CENTER:
+            case GTK_ALIGN_FILL:
+            return 0.5;
+        default:
+            return 0.0;
+    }
 }
 
 /* TODO - Optimize this a bit */
 static void
 calculate_pupil_xy (EyesApplet *eyes_applet,
-		    gint x, gint y,
-		    gint *pupil_x, gint *pupil_y, GtkWidget* widget)
+                    gint        x,
+                    gint        y,
+                    gint       *pupil_x,
+                    gint       *pupil_y,
+                    GtkWidget  *widget)
 {
-        GtkAllocation allocation;
-        double sina;
-        double cosa;
-        double h;
-        double temp;
- 	 double nx, ny;
+    GtkAllocation allocation;
+    double sina;
+    double cosa;
+    double h;
+    double temp;
+    double nx, ny;
 
-	 gfloat xalign, yalign;
-	 gint width, height;
+    gfloat xalign, yalign;
+    gint width, height;
 
-	 gtk_widget_get_allocation (GTK_WIDGET(widget), &allocation);
-	 width = allocation.width;
-	 height = allocation.height;
-	 xalign = gtk_align_to_gfloat (gtk_widget_get_halign (widget));
-	 yalign = gtk_align_to_gfloat (gtk_widget_get_valign (widget));
+    gtk_widget_get_allocation (GTK_WIDGET (widget), &allocation);
+    width = allocation.width;
+    height = allocation.height;
+    xalign = gtk_align_to_gfloat (gtk_widget_get_halign (widget));
+    yalign = gtk_align_to_gfloat (gtk_widget_get_valign (widget));
 
-	 nx = x - MAX(width - eyes_applet->eye_width, 0) * xalign - eyes_applet->eye_width / 2;
-	 ny = y - MAX(height- eyes_applet->eye_height, 0) * yalign - eyes_applet->eye_height / 2;
+    nx = x - MAX (width - eyes_applet->eye_width, 0) * xalign
+         - eyes_applet->eye_width / 2;
+    ny = y - MAX (height - eyes_applet->eye_height, 0) * yalign
+         - eyes_applet->eye_height / 2;
 
-	 h = hypot (nx, ny);
-        if (h < 0.5 || fabs (h)
-            < (fabs (hypot (eyes_applet->eye_height / 2, eyes_applet->eye_width / 2)) - eyes_applet->wall_thickness - eyes_applet->pupil_height)) {
-                *pupil_x = nx + eyes_applet->eye_width / 2;
-                *pupil_y = ny + eyes_applet->eye_height / 2;
-                return;
-        }
+    h = hypot (nx, ny);
+    if (h < 0.5
+        || fabs (h)
+           < (fabs (hypot (eyes_applet->eye_height / 2,
+                           eyes_applet->eye_width / 2))
+              - eyes_applet->wall_thickness
+              - eyes_applet->pupil_height)) {
+        *pupil_x = nx + eyes_applet->eye_width / 2;
+        *pupil_y = ny + eyes_applet->eye_height / 2;
+        return;
+    }
 
-	 sina = nx / h;
-	 cosa = ny / h;
+    sina = nx / h;
+    cosa = ny / h;
 
-        temp = hypot ((eyes_applet->eye_width / 2) * sina, (eyes_applet->eye_height / 2) * cosa);
-        temp -= hypot ((eyes_applet->pupil_width / 2) * sina, (eyes_applet->pupil_height / 2) * cosa);
-        temp -= hypot ((eyes_applet->wall_thickness / 2) * sina, (eyes_applet->wall_thickness / 2) * cosa);
+    temp = hypot ((eyes_applet->eye_width / 2) * sina,
+                  (eyes_applet->eye_height / 2) * cosa);
+    temp -= hypot ((eyes_applet->pupil_width / 2) * sina,
+                   (eyes_applet->pupil_height / 2) * cosa);
+    temp -= hypot ((eyes_applet->wall_thickness / 2) * sina,
+                   (eyes_applet->wall_thickness / 2) * cosa);
 
-        *pupil_x = temp * sina + (eyes_applet->eye_width / 2);
-        *pupil_y = temp * cosa + (eyes_applet->eye_height / 2);
+    *pupil_x = temp * sina + (eyes_applet->eye_width / 2);
+    *pupil_y = temp * cosa + (eyes_applet->eye_height / 2);
 }
 
 static void
 draw_eye (EyesApplet *eyes_applet,
-	  gint eye_num,
-          gint pupil_x,
-          gint pupil_y)
+          gint        eye_num,
+          gint        pupil_x,
+          gint        pupil_y)
 {
-	GdkPixbuf *pixbuf;
-	GdkRectangle rect, r1, r2;
+    GdkPixbuf *pixbuf;
+    GdkRectangle rect, r1, r2;
 
-	pixbuf = gdk_pixbuf_copy (eyes_applet->eye_image);
-	r1.x = pupil_x - eyes_applet->pupil_width / 2;
-	r1.y = pupil_y - eyes_applet->pupil_height / 2;
-	r1.width = eyes_applet->pupil_width;
-	r1.height = eyes_applet->pupil_height;
-	r2.x = 0;
-	r2.y = 0;
-	r2.width = eyes_applet->eye_width;
-	r2.height = eyes_applet->eye_height;
-	gdk_rectangle_intersect (&r1, &r2, &rect);
-	gdk_pixbuf_composite (eyes_applet->pupil_image, pixbuf,
-					   rect.x,
-					   rect.y,
-					   rect.width,
-				      	   rect.height,
-				      	   pupil_x - eyes_applet->pupil_width / 2,
-					   pupil_y - eyes_applet->pupil_height / 2, 1.0, 1.0,
-				      	   GDK_INTERP_BILINEAR,
-				           255);
-	gtk_image_set_from_pixbuf (GTK_IMAGE (eyes_applet->eyes[eye_num]),
-						  pixbuf);
-	g_object_unref (pixbuf);
+    pixbuf = gdk_pixbuf_copy (eyes_applet->eye_image);
+    r1.x = pupil_x - eyes_applet->pupil_width / 2;
+    r1.y = pupil_y - eyes_applet->pupil_height / 2;
+    r1.width = eyes_applet->pupil_width;
+    r1.height = eyes_applet->pupil_height;
+    r2.x = 0;
+    r2.y = 0;
+    r2.width = eyes_applet->eye_width;
+    r2.height = eyes_applet->eye_height;
+    gdk_rectangle_intersect (&r1, &r2, &rect);
+    gdk_pixbuf_composite (eyes_applet->pupil_image, pixbuf,
+                          rect.x, rect.y,
+                          rect.width, rect.height,
+                          pupil_x - eyes_applet->pupil_width / 2,
+                          pupil_y - eyes_applet->pupil_height / 2,
+                          1.0, 1.0,
+                          GDK_INTERP_BILINEAR,
+                          255);
+    gtk_image_set_from_pixbuf (GTK_IMAGE (eyes_applet->eyes[eye_num]), pixbuf);
+    g_object_unref (pixbuf);
 
 }
 
 static gint
 timer_cb (EyesApplet *eyes_applet)
 {
-        GdkDisplay *display;
-        GdkSeat *seat;
-        gint x, y;
-        gint pupil_x, pupil_y;
-        gint i;
+    GdkDisplay *display;
+    GdkSeat *seat;
+    gint x, y;
+    gint pupil_x, pupil_y;
+    gint i;
 
-        display = gtk_widget_get_display (GTK_WIDGET (eyes_applet->applet));
-        seat = gdk_display_get_default_seat (display);
+    display = gtk_widget_get_display (GTK_WIDGET (eyes_applet->applet));
+    seat = gdk_display_get_default_seat (display);
 
-        for (i = 0; i < eyes_applet->num_eyes; i++) {
-		if (gtk_widget_get_realized (eyes_applet->eyes[i])) {
+    for (i = 0; i < eyes_applet->num_eyes; i++) {
+        if (gtk_widget_get_realized (eyes_applet->eyes[i])) {
             gdk_window_get_device_position (gtk_widget_get_window (eyes_applet->eyes[i]),
                                             gdk_seat_get_pointer (seat),
                                             &x, &y, NULL);
 
-			if ((x != eyes_applet->pointer_last_x[i]) || (y != eyes_applet->pointer_last_y[i])) {
+            if ((x != eyes_applet->pointer_last_x[i]) ||
+                (y != eyes_applet->pointer_last_y[i])) {
 
-				calculate_pupil_xy (eyes_applet, x, y, &pupil_x, &pupil_y, eyes_applet->eyes[i]);
-				draw_eye (eyes_applet, i, pupil_x, pupil_y);
+                calculate_pupil_xy (eyes_applet, x, y, &pupil_x, &pupil_y,
+                                    eyes_applet->eyes[i]);
+                draw_eye (eyes_applet, i, pupil_x, pupil_y);
 
-			        eyes_applet->pointer_last_x[i] = x;
-			        eyes_applet->pointer_last_y[i] = y;
-			}
-		}
+                eyes_applet->pointer_last_x[i] = x;
+                eyes_applet->pointer_last_y[i] = y;
+            }
         }
-        return TRUE;
+    }
+    return TRUE;
 }
 
 static void
-about_cb (GtkAction   *action,
-	  EyesApplet  *eyes_applet)
+about_cb (GtkAction  *action,
+          EyesApplet *eyes_applet)
 {
-    static const gchar *authors [] = {
-                "Dave Camp <campd@oit.edu>",
-                NULL
-	};
+    static const gchar *authors[] = {
+        "Dave Camp <campd@oit.edu>",
+        NULL
+    };
 
-	const gchar *documenters[] = {
-                "Arjan Scherpenisse <acscherp@wins.uva.nl>",
-                "Telsa Gwynne <hobbit@aloss.ukuu.org.uk>",
-                N_("Sun GNOME Documentation Team <gdocteam@sun.com>"),
-                N_("MATE Documentation Team"),
-		NULL
-	};
+    const gchar *documenters[] = {
+        "Arjan Scherpenisse <acscherp@wins.uva.nl>",
+        "Telsa Gwynne <hobbit@aloss.ukuu.org.uk>",
+        N_("Sun GNOME Documentation Team <gdocteam@sun.com>"),
+        N_("MATE Documentation Team"),
+        NULL
+    };
 
 #ifdef ENABLE_NLS
-	const char **p;
-	for (p = documenters; *p; ++p)
-		*p = _(*p);
+    const char **p;
+    for (p = documenters; *p; ++p)
+        *p = _(*p);
 #endif
 
-	gtk_show_about_dialog (NULL,
-		"title",              _("About Eyes"),
-		"version",            VERSION,
-		"comments",           _("A goofy set of eyes for the MATE "
-		                      "panel. They follow your mouse."),
-		"copyright",          _("Copyright \xC2\xA9 1999 Dave Camp\n"
-		                        "Copyright \xc2\xa9 2012-2020 MATE developers"),
-		"authors",            authors,
-		"documenters",        documenters,
-		"translator-credits", _("translator-credits"),
-		"logo-icon-name",     "mate-eyes-applet",
-		NULL);
+    gtk_show_about_dialog (NULL,
+                           "title",              _("About Eyes"),
+                           "version",            VERSION,
+                           "comments",           _("A goofy set of eyes for the MATE "
+                                                   "panel. They follow your mouse."),
+                           "copyright",          _("Copyright \xC2\xA9 1999 Dave Camp\n"
+                                                   "Copyright \xc2\xa9 2012-2020 MATE developers"),
+                           "authors",            authors,
+                           "documenters",        documenters,
+                           "translator-credits", _("translator-credits"),
+                           "logo-icon-name",     "mate-eyes-applet",
+                           NULL);
 }
 
 static int
 properties_load (EyesApplet *eyes_applet)
 {
-        gchar *theme_path = NULL;
+    gchar *theme_path = NULL;
 
-	theme_path = g_settings_get_string (eyes_applet->settings, "theme-path");
+    theme_path = g_settings_get_string (eyes_applet->settings, "theme-path");
 
-	if (theme_path == NULL)
-		theme_path = g_strdup (GEYES_THEMES_DIR "Default-tiny");
+    if (theme_path == NULL)
+        theme_path = g_strdup (GEYES_THEMES_DIR "Default-tiny");
 
-        if (load_theme (eyes_applet, theme_path) == FALSE) {
-		g_free (theme_path);
-
-		return FALSE;
-	}
-
+    if (load_theme (eyes_applet, theme_path) == FALSE) {
         g_free (theme_path);
+        return FALSE;
+    }
 
-	return TRUE;
+    g_free (theme_path);
+    return TRUE;
 }
 
 void
 setup_eyes (EyesApplet *eyes_applet)
 {
-	int i;
+    int i;
 
-        eyes_applet->hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-        gtk_box_pack_start (GTK_BOX (eyes_applet->vbox), eyes_applet->hbox, TRUE, TRUE, 0);
+    eyes_applet->hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_box_pack_start (GTK_BOX (eyes_applet->vbox), eyes_applet->hbox, TRUE,
+                        TRUE, 0);
 
-	eyes_applet->eyes = g_new0 (GtkWidget *, eyes_applet->num_eyes);
-	eyes_applet->pointer_last_x = g_new0 (gint, eyes_applet->num_eyes);
-	eyes_applet->pointer_last_y = g_new0 (gint, eyes_applet->num_eyes);
+    eyes_applet->eyes = g_new0 (GtkWidget *, eyes_applet->num_eyes);
+    eyes_applet->pointer_last_x = g_new0 (gint, eyes_applet->num_eyes);
+    eyes_applet->pointer_last_y = g_new0 (gint, eyes_applet->num_eyes);
 
-        for (i = 0; i < eyes_applet->num_eyes; i++) {
-                eyes_applet->eyes[i] = gtk_image_new ();
-                if (eyes_applet->eyes[i] == NULL)
-                        g_error ("Error creating geyes\n");
+    for (i = 0; i < eyes_applet->num_eyes; i++) {
+        if ((eyes_applet->eyes[i] = gtk_image_new ()) == NULL)
+            g_error ("Error creating geyes\n");
 
-		gtk_widget_set_size_request (GTK_WIDGET (eyes_applet->eyes[i]),
-					     eyes_applet->eye_width,
-					     eyes_applet->eye_height);
+        gtk_widget_set_size_request (GTK_WIDGET (eyes_applet->eyes[i]),
+                                     eyes_applet->eye_width,
+                                     eyes_applet->eye_height);
 
-                gtk_widget_show (eyes_applet->eyes[i]);
+        gtk_widget_show (eyes_applet->eyes[i]);
 
-		gtk_box_pack_start (GTK_BOX (eyes_applet->hbox),
-                                    eyes_applet->eyes [i],
-                                    TRUE,
-                                    TRUE,
-                                    0);
+        gtk_box_pack_start (GTK_BOX (eyes_applet->hbox), eyes_applet->eyes[i],
+                            TRUE, TRUE, 0);
 
-		if ((eyes_applet->num_eyes != 1) && (i == 0)) {
-			gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_END);
-			gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
-		}
-		else if ((eyes_applet->num_eyes != 1) && (i == eyes_applet->num_eyes - 1)) {
-			gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_START);
-			gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
-		}
-		else {
-			gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
-			gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
-		}
-
-                gtk_widget_realize (eyes_applet->eyes[i]);
-
-		eyes_applet->pointer_last_x[i] = G_MAXINT;
-		eyes_applet->pointer_last_y[i] = G_MAXINT;
-
-		draw_eye (eyes_applet, i,
-			  eyes_applet->eye_width / 2,
-                          eyes_applet->eye_height / 2);
-
+        if ((eyes_applet->num_eyes != 1) && (i == 0)) {
+            gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_END);
+            gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
+        } else if ((eyes_applet->num_eyes != 1) &&
+                   (i == eyes_applet->num_eyes - 1)) {
+            gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_START);
+            gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
+        } else {
+            gtk_widget_set_halign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
+            gtk_widget_set_valign (eyes_applet->eyes[i], GTK_ALIGN_CENTER);
         }
-        gtk_widget_show (eyes_applet->hbox);
+
+        gtk_widget_realize (eyes_applet->eyes[i]);
+
+        eyes_applet->pointer_last_x[i] = G_MAXINT;
+        eyes_applet->pointer_last_y[i] = G_MAXINT;
+
+        draw_eye (eyes_applet, i, eyes_applet->eye_width / 2,
+                  eyes_applet->eye_height / 2);
+
+    }
+    gtk_widget_show (eyes_applet->hbox);
 }
 
 void
 destroy_eyes (EyesApplet *eyes_applet)
 {
-	gtk_widget_destroy (eyes_applet->hbox);
-	eyes_applet->hbox = NULL;
+    gtk_widget_destroy (eyes_applet->hbox);
+    eyes_applet->hbox = NULL;
 
-	g_free (eyes_applet->eyes);
-	g_free (eyes_applet->pointer_last_x);
-	g_free (eyes_applet->pointer_last_y);
+    g_free (eyes_applet->eyes);
+    g_free (eyes_applet->pointer_last_x);
+    g_free (eyes_applet->pointer_last_y);
 }
 
-static EyesApplet *
+static EyesApplet*
 create_eyes (MatePanelApplet *applet)
 {
-	EyesApplet *eyes_applet = g_new0 (EyesApplet, 1);
+    EyesApplet *eyes_applet = g_new0 (EyesApplet, 1);
 
-        eyes_applet->applet = applet;
-        eyes_applet->vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
-	eyes_applet->settings =
-		mate_panel_applet_settings_new (applet, "org.mate.panel.applet.geyes");
-
-	gtk_container_add (GTK_CONTAINER (applet), eyes_applet->vbox);
-
-	return eyes_applet;
+    eyes_applet->applet = applet;
+    eyes_applet->vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+    eyes_applet->settings =
+        mate_panel_applet_settings_new (applet,
+                                        "org.mate.panel.applet.geyes");
+    gtk_container_add (GTK_CONTAINER (applet), eyes_applet->vbox);
+    return eyes_applet;
 }
 
 static void
-destroy_cb (GObject *object, EyesApplet *eyes_applet)
+destroy_cb (GObject    *object,
+            EyesApplet *eyes_applet)
 {
-	g_return_if_fail (eyes_applet);
+    g_return_if_fail (eyes_applet);
 
-	g_source_remove (eyes_applet->timeout_id);
-	if (eyes_applet->hbox)
-		destroy_eyes (eyes_applet);
-	eyes_applet->timeout_id = 0;
-	if (eyes_applet->eye_image)
-		g_object_unref (eyes_applet->eye_image);
-	eyes_applet->eye_image = NULL;
-	if (eyes_applet->pupil_image)
-		g_object_unref (eyes_applet->pupil_image);
-	eyes_applet->pupil_image = NULL;
-	if (eyes_applet->theme_dir)
-		g_free (eyes_applet->theme_dir);
-	eyes_applet->theme_dir = NULL;
-	if (eyes_applet->theme_name)
-		g_free (eyes_applet->theme_name);
-	eyes_applet->theme_name = NULL;
-	if (eyes_applet->eye_filename)
-		g_free (eyes_applet->eye_filename);
-	eyes_applet->eye_filename = NULL;
-	if (eyes_applet->pupil_filename)
-		g_free (eyes_applet->pupil_filename);
-	eyes_applet->pupil_filename = NULL;
+    g_source_remove (eyes_applet->timeout_id);
 
-	if (eyes_applet->prop_box.pbox)
-		gtk_widget_destroy (eyes_applet->prop_box.pbox);
+    if (eyes_applet->hbox)
+        destroy_eyes (eyes_applet);
+    eyes_applet->timeout_id = 0;
 
-	if (eyes_applet->settings)
-		g_object_unref (eyes_applet->settings);
-	eyes_applet->settings = NULL;
+    if (eyes_applet->eye_image)
+        g_object_unref (eyes_applet->eye_image);
+    eyes_applet->eye_image = NULL;
 
-	g_free (eyes_applet);
+    if (eyes_applet->pupil_image)
+        g_object_unref (eyes_applet->pupil_image);
+    eyes_applet->pupil_image = NULL;
+
+    if (eyes_applet->theme_dir)
+        g_free (eyes_applet->theme_dir);
+    eyes_applet->theme_dir = NULL;
+
+    if (eyes_applet->theme_name)
+        g_free (eyes_applet->theme_name);
+    eyes_applet->theme_name = NULL;
+
+    if (eyes_applet->eye_filename)
+        g_free (eyes_applet->eye_filename);
+    eyes_applet->eye_filename = NULL;
+
+    if (eyes_applet->pupil_filename)
+        g_free (eyes_applet->pupil_filename);
+    eyes_applet->pupil_filename = NULL;
+
+    if (eyes_applet->prop_box.pbox)
+        gtk_widget_destroy (eyes_applet->prop_box.pbox);
+
+    if (eyes_applet->settings)
+        g_object_unref (eyes_applet->settings);
+    eyes_applet->settings = NULL;
+
+    g_free (eyes_applet);
 }
 
 static void
 help_cb (GtkAction  *action,
-	 EyesApplet *eyes_applet)
+         EyesApplet *eyes_applet)
 {
-	GError *error = NULL;
+    GError *error = NULL;
 
-	gtk_show_uri_on_window (NULL,
-	                        "help:mate-geyes",
-	                        gtk_get_current_event_time (),
-	                        &error);
+    gtk_show_uri_on_window (NULL, "help:mate-geyes",
+                            gtk_get_current_event_time (),
+                            &error);
 
-	if (error) {
-		GtkWidget *dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-							    _("There was an error displaying help: %s"), error->message);
-		g_signal_connect (G_OBJECT (dialog), "response", G_CALLBACK (gtk_widget_destroy), NULL);
-		gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
-		gtk_window_set_screen (GTK_WINDOW (dialog), gtk_widget_get_screen (GTK_WIDGET (eyes_applet->applet)));
-		gtk_widget_show (dialog);
-		g_error_free (error);
-		error = NULL;
-	}
+    if (error) {
+        GtkWidget *dialog
+            = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,
+                                      GTK_MESSAGE_ERROR,
+                                      GTK_BUTTONS_CLOSE,
+                                      _("There was an error displaying help: %s"),
+                                      error->message);
+        g_signal_connect (G_OBJECT (dialog), "response",
+                          G_CALLBACK (gtk_widget_destroy),
+                          NULL);
+        gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
+        gtk_window_set_screen (GTK_WINDOW (dialog),
+                               gtk_widget_get_screen (GTK_WIDGET (eyes_applet->applet)));
+        gtk_widget_show (dialog);
+        g_error_free (error);
+        error = NULL;
+    }
 }
 
-
-static const GtkActionEntry geyes_applet_menu_actions [] = {
-	{ "Props", "document-properties", N_("_Preferences"),
-	  NULL, NULL,
-	  G_CALLBACK (properties_cb) },
-	{ "Help", "help-browser", N_("_Help"),
-	  NULL, NULL,
-	  G_CALLBACK (help_cb) },
-	{ "About", "help-about", N_("_About"),
-	  NULL, NULL,
-	  G_CALLBACK (about_cb) }
+static const GtkActionEntry geyes_applet_menu_actions[] = {
+        { "Props", "document-properties", N_("_Preferences"),
+          NULL, NULL, G_CALLBACK (properties_cb) },
+        { "Help", "help-browser", N_("_Help"),
+          NULL, NULL, G_CALLBACK (help_cb) },
+        { "About", "help-about", N_("_About"),
+          NULL, NULL, G_CALLBACK (about_cb) }
 };
 
 static void
-set_atk_name_description (GtkWidget *widget, const gchar *name,
-    const gchar *description)
+set_atk_name_description (GtkWidget   *widget,
+                          const gchar *name,
+                          const gchar *description)
 {
-	AtkObject *aobj;
+    AtkObject *aobj;
 
-	aobj = gtk_widget_get_accessible (widget);
-	/* Check if gail is loaded */
-	if (GTK_IS_ACCESSIBLE (aobj) == FALSE)
-		return;
+    aobj = gtk_widget_get_accessible (widget);
 
-	atk_object_set_name (aobj, name);
-	atk_object_set_description (aobj, description);
+    /* Check if gail is loaded */
+    if (GTK_IS_ACCESSIBLE (aobj) == FALSE)
+        return;
+
+    atk_object_set_name (aobj, name);
+    atk_object_set_description (aobj, description);
 }
 
 static gboolean
 geyes_applet_fill (MatePanelApplet *applet)
 {
-	EyesApplet *eyes_applet;
-	GtkActionGroup *action_group;
+    EyesApplet *eyes_applet;
+    GtkActionGroup *action_group;
 
-	g_set_application_name (_("Eyes"));
+    g_set_application_name (_("Eyes"));
+    gtk_window_set_default_icon_name ("mate-eyes-applet");
+    mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 
-	gtk_window_set_default_icon_name ("mate-eyes-applet");
-	mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
+    eyes_applet = create_eyes (applet);
 
-        eyes_applet = create_eyes (applet);
+    eyes_applet->timeout_id = g_timeout_add (UPDATE_TIMEOUT,
+                                             (GSourceFunc) timer_cb,
+                                             eyes_applet);
 
-        eyes_applet->timeout_id = g_timeout_add (
-		UPDATE_TIMEOUT, (GSourceFunc) timer_cb, eyes_applet);
+    action_group = gtk_action_group_new ("Geyes Applet Actions");
+    gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
 
-	action_group = gtk_action_group_new ("Geyes Applet Actions");
-	gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
+    gtk_action_group_add_actions (action_group, geyes_applet_menu_actions,
+                                  G_N_ELEMENTS (geyes_applet_menu_actions),
+                                  eyes_applet);
 
-	gtk_action_group_add_actions (action_group,
-	                              geyes_applet_menu_actions,
-	                              G_N_ELEMENTS (geyes_applet_menu_actions),
-	                              eyes_applet);
+    mate_panel_applet_setup_menu_from_resource (eyes_applet->applet,
+                                                GEYES_RESOURCE_PATH "geyes-applet-menu.xml",
+                                                action_group);
 
-	mate_panel_applet_setup_menu_from_resource (eyes_applet->applet,
-	                                            GEYES_RESOURCE_PATH "geyes-applet-menu.xml",
-	                                            action_group);
+    if (mate_panel_applet_get_locked_down (eyes_applet->applet)) {
+        GtkAction *action;
 
-	if (mate_panel_applet_get_locked_down (eyes_applet->applet)) {
-		GtkAction *action;
+        action = gtk_action_group_get_action (action_group, "Props");
+        gtk_action_set_visible (action, FALSE);
+    }
+    g_object_unref (action_group);
 
-		action = gtk_action_group_get_action (action_group, "Props");
-		gtk_action_set_visible (action, FALSE);
-	}
-	g_object_unref (action_group);
+    gtk_widget_set_tooltip_text (GTK_WIDGET (eyes_applet->applet), _("Eyes"));
 
-	gtk_widget_set_tooltip_text (GTK_WIDGET (eyes_applet->applet), _("Eyes"));
+    set_atk_name_description (GTK_WIDGET (eyes_applet->applet), _("Eyes"),
+                              _("The eyes look in the direction of the mouse pointer"));
 
-	set_atk_name_description (GTK_WIDGET (eyes_applet->applet), _("Eyes"),
-			_("The eyes look in the direction of the mouse pointer"));
+    g_signal_connect (eyes_applet->vbox,
+                      "destroy",
+                      G_CALLBACK (destroy_cb),
+                      eyes_applet);
 
-	g_signal_connect (eyes_applet->vbox,
-			  "destroy",
-			  G_CALLBACK (destroy_cb),
-			  eyes_applet);
+    gtk_widget_show_all (GTK_WIDGET (eyes_applet->applet));
 
-	gtk_widget_show_all (GTK_WIDGET (eyes_applet->applet));
+    /* setup here and not in create eyes so the destroy signal is set so
+     * that when there is an error within loading the theme
+     * we can emit this signal */
+    if (properties_load (eyes_applet) == FALSE)
+        return FALSE;
 
-	/* setup here and not in create eyes so the destroy signal is set so
-	 * that when there is an error within loading the theme
-	 * we can emit this signal */
-        if (properties_load (eyes_applet) == FALSE)
-		return FALSE;
+    setup_eyes (eyes_applet);
 
-	setup_eyes (eyes_applet);
-
-	return TRUE;
+    return TRUE;
 }
 
 static gboolean
 geyes_applet_factory (MatePanelApplet *applet,
-		      const gchar *iid,
-		      gpointer     data)
+                      const gchar     *iid,
+                      gpointer         data)
 {
-	gboolean retval = FALSE;
+    gboolean retval = FALSE;
 
-	theme_dirs_create ();
+    theme_dirs_create ();
 
-	if (!strcmp (iid, "GeyesApplet"))
-		retval = geyes_applet_fill (applet);
+    if (!strcmp (iid, "GeyesApplet"))
+        retval = geyes_applet_fill (applet);
 
-	if (retval == FALSE) {
-		exit (-1);
-	}
+    if (retval == FALSE) {
+        exit (-1);
+    }
 
-	return retval;
+    return retval;
 }
 
 MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("GeyesAppletFactory",
-				  PANEL_TYPE_APPLET,
-				  "geyes",
-				  geyes_applet_factory,
-				  NULL)
+                                       PANEL_TYPE_APPLET,
+                                       "geyes",
+                                       geyes_applet_factory,
+                                       NULL)

--- a/geyes/src/geyes.h
+++ b/geyes/src/geyes.h
@@ -26,6 +26,9 @@
 #include <mate-panel-applet.h>
 
 #define MAX_EYES 1000
+#define GEYES_SETTINGS_SCHEMA "org.mate.panel.applet.geyes"
+#define GEYES_SETTINGS_THEME_PATH_KEY "theme-path"
+
 typedef struct
 {
     GtkWidget *pbox;

--- a/geyes/src/geyes.h
+++ b/geyes/src/geyes.h
@@ -1,20 +1,18 @@
-/*
- * Copyright (C) 1999 Dave Camp <dave@davec.dhs.org>
- *  
+/* Copyright (C) 1999 Dave Camp <dave@davec.dhs.org>
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
- *  
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *  
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
- *  
  */
 
 #ifndef __GEYES_H__
@@ -30,56 +28,52 @@
 #define MAX_EYES 1000
 typedef struct
 {
-	GtkWidget *pbox;
-    
-	gint selected_row;
+    GtkWidget *pbox;
+
+    gint selected_row;
 } EyesPropertyBox;
 
-typedef struct 
+typedef struct
 {
-	/* Applet */
-	MatePanelApplet *applet;
-	GtkWidget   *vbox;
-	GtkWidget   *hbox;
-	GtkWidget   **eyes;
-	guint        timeout_id;
-	gint 	    *pointer_last_x;
-	gint 	    *pointer_last_y;
+    /* Applet */
+    MatePanelApplet *applet;
+    GtkWidget       *vbox;
+    GtkWidget       *hbox;
+    GtkWidget      **eyes;
+    guint            timeout_id;
+    gint            *pointer_last_x;
+    gint            *pointer_last_y;
 
-	/* Theme */
-	GdkPixbuf *eye_image;
-	GdkPixbuf *pupil_image;
-	gchar *theme_dir;
-	gchar *theme_name;
-	gchar *eye_filename;
-	gchar *pupil_filename;
-	gint num_eyes;
-	gint eye_height;
-	gint eye_width;
-	gint pupil_height;
-	gint pupil_width;
-	gint wall_thickness;
+    /* Theme */
+    GdkPixbuf       *eye_image;
+    GdkPixbuf       *pupil_image;
+    gchar           *theme_dir;
+    gchar           *theme_name;
+    gchar           *eye_filename;
+    gchar           *pupil_filename;
+    gint             num_eyes;
+    gint             eye_height;
+    gint             eye_width;
+    gint             pupil_height;
+    gint             pupil_width;
+    gint             wall_thickness;
 
-	/* Properties */
-	EyesPropertyBox prop_box;
+    /* Properties */
+    EyesPropertyBox  prop_box;
 
-	/* Settings */
-	GSettings *settings;
+    /* Settings */
+    GSettings       *settings;
 } EyesApplet;
 
 /* eyes.c */
-void setup_eyes   (EyesApplet *eyes_applet);
-
-void destroy_eyes (EyesApplet *eyes_applet);
-
+void   setup_eyes         (EyesApplet  *eyes_applet);
+void   destroy_eyes       (EyesApplet  *eyes_applet);
 
 /* theme.c */
-void theme_dirs_create (void);
-
-int load_theme    (EyesApplet        *eyes_applet,
-		   const gchar       *theme_dir);
-
-void properties_cb (GtkAction         *action,
-		    EyesApplet        *eyes_applet);
+void    theme_dirs_create (void);
+int     load_theme        (EyesApplet  *eyes_applet,
+                           const gchar *theme_dir);
+void    properties_cb     (GtkAction   *action,
+                           EyesApplet  *eyes_applet);
 
 #endif

--- a/geyes/src/themes.c
+++ b/geyes/src/themes.c
@@ -238,8 +238,7 @@ phelp_cb (GtkDialog *dialog)
         gtk_window_set_screen (GTK_WINDOW (error_dialog),
                                gtk_widget_get_screen (GTK_WIDGET (dialog)));
         gtk_widget_show (error_dialog);
-        g_error_free (error);
-        error = NULL;
+        g_clear_error (&error);
     }
 }
 

--- a/geyes/src/themes.c
+++ b/geyes/src/themes.c
@@ -60,7 +60,7 @@ parse_theme_file (EyesApplet *eyes_applet,
     gchar *token;
 
     if (fgets (line_buf, 512, theme_file) == NULL)
-        printf ("fgets error\n");
+        g_debug ("fgets error");
 
     while (!feof (theme_file)) {
         token = strtok (line_buf, "=");
@@ -94,7 +94,7 @@ parse_theme_file (EyesApplet *eyes_applet,
                 = g_strdup_printf ("%s%s", eyes_applet->theme_dir, token);
         }
         if (fgets (line_buf, 512, theme_file) == NULL)
-            printf ("fgets error\n");
+            g_debug ("fgets error");
     }
 }
 

--- a/geyes/src/themes.c
+++ b/geyes/src/themes.c
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
- *
  */
 
 #include <config.h>
@@ -27,325 +26,338 @@
 #include "geyes.h"
 
 #define GET_WIDGET(x) (GTK_WIDGET (gtk_builder_get_object (builder, (x))))
-
 #define NUM_THEME_DIRECTORIES 2
 
 static char *theme_directories[NUM_THEME_DIRECTORIES];
 
 enum {
-	COL_THEME_DIR = 0,
-	COL_THEME_NAME,
-	TOTAL_COLS
+    COL_THEME_DIR = 0,
+    COL_THEME_NAME,
+    TOTAL_COLS
 };
 
-void theme_dirs_create (void)
+void
+theme_dirs_create (void)
 {
-	static gboolean themes_created = FALSE;
+    static gboolean themes_created = FALSE;
 
-	if (themes_created == TRUE)
-		return;
+    if (themes_created == TRUE)
+        return;
 
-	theme_directories[0] = g_build_filename(GEYES_THEMES_DIR, NULL);
+    theme_directories[0] = g_build_filename (GEYES_THEMES_DIR, NULL);
 
-		theme_directories[1] = g_build_filename(g_get_user_config_dir(), "mate", "geyes-themes", NULL);
+    theme_directories[1] = g_build_filename (g_get_user_config_dir (), "mate",
+                                             "geyes-themes", NULL);
 
-	themes_created = TRUE;
+    themes_created = TRUE;
 }
 
 static void
-parse_theme_file (EyesApplet *eyes_applet, FILE *theme_file)
+parse_theme_file (EyesApplet *eyes_applet,
+                  FILE       *theme_file)
 {
-        gchar line_buf [512]; /* prolly overkill */
-        gchar *token;
+    gchar line_buf[512]; /* prolly overkill */
+    gchar *token;
 
-        if (fgets (line_buf, 512, theme_file) == NULL)
-               printf("fgets error\n");
+    if (fgets (line_buf, 512, theme_file) == NULL)
+        printf ("fgets error\n");
 
-        while (!feof (theme_file)) {
-                token = strtok (line_buf, "=");
-                if (strncmp (token, "wall-thickness",
-                             strlen ("wall-thickness")) == 0) {
-                        token += strlen ("wall-thickness");
-                        while (!isdigit (*token)) {
-                                token++;
-                        }
-                        sscanf (token, "%d", &eyes_applet->wall_thickness);
-                } else if (strncmp (token, "num-eyes", strlen ("num-eyes")) == 0) {
-                        token += strlen ("num-eyes");
-                        while (!isdigit (*token)) {
-                                token++;
-                        }
-                        sscanf (token, "%d", &eyes_applet->num_eyes);
-			if (eyes_applet->num_eyes > MAX_EYES)
-				eyes_applet->num_eyes = MAX_EYES;
-                } else if (strncmp (token, "eye-pixmap", strlen ("eye-pixmap")) == 0) {
-                        token = strtok (NULL, "\"");
-                        token = strtok (NULL, "\"");
-                        if (eyes_applet->eye_filename != NULL)
-                                g_free (eyes_applet->eye_filename);
-                        eyes_applet->eye_filename = g_strdup_printf ("%s%s",
-                                                                    eyes_applet->theme_dir,
-                                                                    token);
-                } else if (strncmp (token, "pupil-pixmap", strlen ("pupil-pixmap")) == 0) {
-                        token = strtok (NULL, "\"");
-                        token = strtok (NULL, "\"");
+    while (!feof (theme_file)) {
+        token = strtok (line_buf, "=");
+        if (strncmp (token, "wall-thickness", strlen ("wall-thickness")) == 0) {
+            token += strlen ("wall-thickness");
+            while (!isdigit (*token)) {
+                token++;
+            }
+            sscanf (token, "%d", &eyes_applet->wall_thickness);
+        } else if (strncmp (token, "num-eyes", strlen ("num-eyes")) == 0) {
+            token += strlen ("num-eyes");
+            while (!isdigit (*token)) {
+                token++;
+            }
+            sscanf (token, "%d", &eyes_applet->num_eyes);
+            if (eyes_applet->num_eyes > MAX_EYES)
+                eyes_applet->num_eyes = MAX_EYES;
+        } else if (strncmp (token, "eye-pixmap", strlen ("eye-pixmap")) == 0) {
+            token = strtok (NULL, "\"");
+            token = strtok (NULL, "\"");
+            if (eyes_applet->eye_filename != NULL)
+                g_free (eyes_applet->eye_filename);
+            eyes_applet->eye_filename
+                = g_strdup_printf ("%s%s", eyes_applet->theme_dir, token);
+        } else if (strncmp (token, "pupil-pixmap", strlen ("pupil-pixmap")) == 0) {
+            token = strtok (NULL, "\"");
+            token = strtok (NULL, "\"");
             if (eyes_applet->pupil_filename != NULL)
-                    g_free (eyes_applet->pupil_filename);
+                g_free (eyes_applet->pupil_filename);
             eyes_applet->pupil_filename
-                    = g_strdup_printf ("%s%s",
-                                       eyes_applet->theme_dir,
-                                       token);
-                }
-                if (fgets (line_buf, 512, theme_file) == NULL)
-                        printf("fgets error\n");
+                = g_strdup_printf ("%s%s", eyes_applet->theme_dir, token);
         }
+        if (fgets (line_buf, 512, theme_file) == NULL)
+            printf ("fgets error\n");
+    }
 }
 
 int
-load_theme (EyesApplet *eyes_applet, const gchar *theme_dir)
+load_theme (EyesApplet  *eyes_applet,
+            const gchar *theme_dir)
 {
-	GtkWidget *dialog;
+    GtkWidget *dialog;
+    FILE      *theme_file;
+    gchar     *file_name;
 
-	FILE* theme_file;
-        gchar *file_name;
+    eyes_applet->theme_dir = g_strdup_printf ("%s/", theme_dir);
 
-        eyes_applet->theme_dir = g_strdup_printf ("%s/", theme_dir);
+    file_name = g_strdup_printf ("%s%s", theme_dir, "/config");
+    theme_file = fopen (file_name, "r");
+    g_free (file_name);
 
-        file_name = g_strdup_printf("%s%s",theme_dir,"/config");
-        theme_file = fopen (file_name, "r");
-        g_free (file_name);
-        if (theme_file == NULL) {
-        	g_free (eyes_applet->theme_dir);
-        	eyes_applet->theme_dir = g_strdup_printf (GEYES_THEMES_DIR "Default-tiny/");
-                theme_file = fopen (GEYES_THEMES_DIR "Default-tiny/config", "r");
-        }
+    if (theme_file == NULL) {
+        g_free (eyes_applet->theme_dir);
 
-	/* if it's still NULL we've got a major problem */
-	if (theme_file == NULL) {
-		dialog = gtk_message_dialog_new_with_markup (NULL,
-				GTK_DIALOG_DESTROY_WITH_PARENT,
-				GTK_MESSAGE_ERROR,
-				GTK_BUTTONS_OK,
-				"<b>%s</b>\n\n%s",
-				_("Can not launch the eyes applet."),
-				_("There was a fatal error while trying to load the theme."));
+        eyes_applet->theme_dir = g_strdup_printf (GEYES_THEMES_DIR "Default-tiny/");
+        theme_file = fopen (GEYES_THEMES_DIR "Default-tiny/config", "r");
+    }
 
-		gtk_dialog_run (GTK_DIALOG (dialog));
-		gtk_widget_destroy (dialog);
+    /* if it's still NULL we've got a major problem */
+    if (theme_file == NULL) {
+        dialog = gtk_message_dialog_new_with_markup (NULL,
+                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                     GTK_MESSAGE_ERROR, GTK_BUTTONS_OK,
+                                                     "<b>%s</b>\n\n%s",
+                                                     _("Can not launch the eyes applet."),
+                                                     _("There was a fatal error while trying to load the theme."));
 
-		gtk_widget_destroy (GTK_WIDGET (eyes_applet->applet));
+        gtk_dialog_run (GTK_DIALOG (dialog));
+        gtk_widget_destroy (dialog);
 
-		return FALSE;
-	}
+        gtk_widget_destroy (GTK_WIDGET (eyes_applet->applet));
 
-        parse_theme_file (eyes_applet, theme_file);
-        fclose (theme_file);
+        return FALSE;
+    }
 
-        eyes_applet->theme_name = g_strdup (theme_dir);
+    parse_theme_file (eyes_applet, theme_file);
+    fclose (theme_file);
 
-        if (eyes_applet->eye_image)
-        	g_object_unref (eyes_applet->eye_image);
-        eyes_applet->eye_image = gdk_pixbuf_new_from_file (eyes_applet->eye_filename, NULL);
-        if (eyes_applet->pupil_image)
-        	g_object_unref (eyes_applet->pupil_image);
-        eyes_applet->pupil_image = gdk_pixbuf_new_from_file (eyes_applet->pupil_filename, NULL);
+    eyes_applet->theme_name = g_strdup (theme_dir);
 
-	eyes_applet->eye_height = gdk_pixbuf_get_height (eyes_applet->eye_image);
-        eyes_applet->eye_width = gdk_pixbuf_get_width (eyes_applet->eye_image);
-        eyes_applet->pupil_height = gdk_pixbuf_get_height (eyes_applet->pupil_image);
-        eyes_applet->pupil_width = gdk_pixbuf_get_width (eyes_applet->pupil_image);
+    if (eyes_applet->eye_image)
+        g_object_unref (eyes_applet->eye_image);
 
-	return TRUE;
+    eyes_applet->eye_image
+        = gdk_pixbuf_new_from_file (eyes_applet->eye_filename,
+                                    NULL);
+
+    if (eyes_applet->pupil_image)
+        g_object_unref (eyes_applet->pupil_image);
+
+    eyes_applet->pupil_image
+        = gdk_pixbuf_new_from_file (eyes_applet->pupil_filename,
+                                    NULL);
+
+    eyes_applet->eye_height = gdk_pixbuf_get_height (eyes_applet->eye_image);
+    eyes_applet->eye_width = gdk_pixbuf_get_width (eyes_applet->eye_image);
+    eyes_applet->pupil_height = gdk_pixbuf_get_height (eyes_applet->pupil_image);
+    eyes_applet->pupil_width = gdk_pixbuf_get_width (eyes_applet->pupil_image);
+
+    return TRUE;
 }
 
 static void
 destroy_theme (EyesApplet *eyes_applet)
 {
-	/* Dunno about this - to unref or not to unref? */
-	if (eyes_applet->eye_image != NULL) {
-        	g_object_unref (eyes_applet->eye_image);
-        	eyes_applet->eye_image = NULL;
-        }
-        if (eyes_applet->pupil_image != NULL) {
-        	g_object_unref (eyes_applet->pupil_image);
-        	eyes_applet->pupil_image = NULL;
-	}
+    /* Dunno about this - to unref or not to unref? */
+    if (eyes_applet->eye_image != NULL) {
+        g_object_unref (eyes_applet->eye_image);
+        eyes_applet->eye_image = NULL;
+    }
+    if (eyes_applet->pupil_image != NULL) {
+        g_object_unref (eyes_applet->pupil_image);
+        eyes_applet->pupil_image = NULL;
+    }
 
-        g_free (eyes_applet->theme_dir);
-        g_free (eyes_applet->theme_name);
+    g_free (eyes_applet->theme_dir);
+    g_free (eyes_applet->theme_name);
 }
 
 static void
-theme_selected_cb (GtkTreeSelection *selection, gpointer data)
+theme_selected_cb (GtkTreeSelection *selection,
+                   gpointer          data)
 {
-	EyesApplet *eyes_applet = data;
-	GtkTreeModel *model;
-	GtkTreeIter iter;
-	gchar *theme;
-	gchar *theme_dir;
+    EyesApplet *eyes_applet = data;
+    GtkTreeModel *model;
+    GtkTreeIter iter;
+    gchar *theme;
+    gchar *theme_dir;
 
-	if (!gtk_tree_selection_get_selected (selection, &model, &iter))
-		return;
+    if (!gtk_tree_selection_get_selected (selection, &model, &iter))
+        return;
 
-	gtk_tree_model_get (model, &iter, COL_THEME_DIR, &theme, -1);
+    gtk_tree_model_get (model, &iter, COL_THEME_DIR, &theme, -1);
 
-	g_return_if_fail (theme);
+    g_return_if_fail (theme);
 
-	theme_dir = g_strdup_printf ("%s/", theme);
-	if (!g_ascii_strncasecmp (theme_dir, eyes_applet->theme_dir, strlen (theme_dir))) {
-		g_free (theme_dir);
-		return;
-	}
-	g_free (theme_dir);
+    theme_dir = g_strdup_printf ("%s/", theme);
+    if (!g_ascii_strncasecmp (theme_dir, eyes_applet->theme_dir,
+                              strlen (theme_dir))) {
+        g_free (theme_dir);
+        return;
+    }
+    g_free (theme_dir);
 
-	destroy_eyes (eyes_applet);
-        destroy_theme (eyes_applet);
-        load_theme (eyes_applet, theme);
-        setup_eyes (eyes_applet);
+    destroy_eyes (eyes_applet);
+    destroy_theme (eyes_applet);
+    load_theme (eyes_applet, theme);
+    setup_eyes (eyes_applet);
 
-	g_settings_set_string (
-		eyes_applet->settings, "theme-path", theme);
+    g_settings_set_string (eyes_applet->settings, "theme-path", theme);
 
-	g_free (theme);
+    g_free (theme);
 }
 
 static void
 phelp_cb (GtkDialog *dialog)
 {
-	GError *error = NULL;
+    GError *error = NULL;
 
-	gtk_show_uri_on_window (GTK_WINDOW (dialog),
-	                        "help:mate-geyes/geyes-settings",
-	                        gtk_get_current_event_time (),
-	                        &error);
+    gtk_show_uri_on_window (GTK_WINDOW (dialog), "help:mate-geyes/geyes-settings",
+                            gtk_get_current_event_time (),
+                            &error);
 
-	if (error) {
-		GtkWidget *error_dialog = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-								  _("There was an error displaying help: %s"), error->message);
-		g_signal_connect (G_OBJECT (error_dialog), "response", G_CALLBACK (gtk_widget_destroy) , NULL);
-		gtk_window_set_resizable (GTK_WINDOW (error_dialog), FALSE);
-		gtk_window_set_screen (GTK_WINDOW (error_dialog), gtk_widget_get_screen (GTK_WIDGET (dialog)));
-		gtk_widget_show (error_dialog);
-		g_error_free (error);
-		error = NULL;
-	}
+    if (error) {
+        GtkWidget *error_dialog
+            = gtk_message_dialog_new (NULL, GTK_DIALOG_MODAL,
+                                      GTK_MESSAGE_ERROR,
+                                      GTK_BUTTONS_CLOSE,
+                                      _("There was an error displaying help: %s"),
+                                      error->message);
+        g_signal_connect (G_OBJECT (error_dialog), "response",
+                          G_CALLBACK (gtk_widget_destroy),
+                          NULL);
+        gtk_window_set_resizable (GTK_WINDOW (error_dialog), FALSE);
+        gtk_window_set_screen (GTK_WINDOW (error_dialog),
+                               gtk_widget_get_screen (GTK_WIDGET (dialog)));
+        gtk_widget_show (error_dialog);
+        g_error_free (error);
+        error = NULL;
+    }
 }
 
 static void
-presponse_cb (GtkDialog *dialog, gint id, gpointer data)
+presponse_cb (GtkDialog *dialog,
+              gint       id,
+              gpointer   data)
 {
-	EyesApplet *eyes_applet = data;
-	if(id == GTK_RESPONSE_HELP){
-		phelp_cb (dialog);
-		return;
-	}
+    EyesApplet *eyes_applet = data;
+    if (id == GTK_RESPONSE_HELP) {
+        phelp_cb (dialog);
+        return;
+    }
 
+    gtk_widget_destroy (GTK_WIDGET (dialog));
 
-	gtk_widget_destroy (GTK_WIDGET (dialog));
-
-	eyes_applet->prop_box.pbox = NULL;
+    eyes_applet->prop_box.pbox = NULL;
 }
 
 void
 properties_cb (GtkAction  *action,
-	       EyesApplet *eyes_applet)
+               EyesApplet *eyes_applet)
 {
-        GtkBuilder *builder;
-        GtkWidget *tree;
-        GtkWidget *label;
-        GtkListStore *model;
-        GtkTreeViewColumn *column;
-        GtkCellRenderer *cell;
-        GtkTreeIter iter;
-        DIR *dfd;
-        struct dirent *dp;
-        int i;
+    GtkBuilder *builder;
+    GtkWidget *tree;
+    GtkWidget *label;
+    GtkListStore *model;
+    GtkTreeViewColumn *column;
+    GtkCellRenderer *cell;
+    GtkTreeIter iter;
+    DIR *dfd;
+    struct dirent *dp;
+    int i;
 #ifdef PATH_MAX
-        gchar filename [PATH_MAX];
+    gchar filename [PATH_MAX];
 #else
-        gchar *filename;
+    gchar *filename;
 #endif
 
-	if (eyes_applet->prop_box.pbox) {
-		gtk_window_set_screen (
-			GTK_WINDOW (eyes_applet->prop_box.pbox),
-			gtk_widget_get_screen (GTK_WIDGET (eyes_applet->applet)));
-		gtk_window_present (GTK_WINDOW (eyes_applet->prop_box.pbox));
-		return;
-	}
+    if (eyes_applet->prop_box.pbox) {
+        gtk_window_set_screen (GTK_WINDOW (eyes_applet->prop_box.pbox),
+                               gtk_widget_get_screen (GTK_WIDGET (eyes_applet->applet)));
 
-	builder = gtk_builder_new_from_resource (GEYES_RESOURCE_PATH "themes.ui");
+        gtk_window_present (GTK_WINDOW (eyes_applet->prop_box.pbox));
+        return;
+    }
 
-	eyes_applet->prop_box.pbox = GET_WIDGET ("preferences_dialog");
-	tree = GET_WIDGET ("themes_treeview");
-	label = GET_WIDGET ("select_theme_label");
+    builder = gtk_builder_new_from_resource (GEYES_RESOURCE_PATH "themes.ui");
 
-	model = gtk_list_store_new (TOTAL_COLS, G_TYPE_STRING, G_TYPE_STRING);
-	gtk_tree_view_set_model (GTK_TREE_VIEW (tree), GTK_TREE_MODEL (model));
-	cell = gtk_cell_renderer_text_new ();
-	column = gtk_tree_view_column_new_with_attributes ("not used", cell,
-                                                           "text", COL_THEME_NAME, NULL);
-        gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
+    eyes_applet->prop_box.pbox = GET_WIDGET("preferences_dialog");
+    tree = GET_WIDGET("themes_treeview");
+    label = GET_WIDGET("select_theme_label");
 
-	if ( ! g_settings_is_writable (eyes_applet->settings, "theme-path")) {
-		gtk_widget_set_sensitive (tree, FALSE);
-		gtk_widget_set_sensitive (label, FALSE);
-	}
+    model = gtk_list_store_new (TOTAL_COLS, G_TYPE_STRING, G_TYPE_STRING);
+    gtk_tree_view_set_model (GTK_TREE_VIEW (tree), GTK_TREE_MODEL (model));
+    cell = gtk_cell_renderer_text_new ();
+    column = gtk_tree_view_column_new_with_attributes ("not used", cell, "text",
+                                                       COL_THEME_NAME,
+                                                       NULL);
+    gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 
-        for (i = 0; i < NUM_THEME_DIRECTORIES; i++) {
-                if ((dfd = opendir (theme_directories[i])) != NULL) {
-                        while ((dp = readdir (dfd)) != NULL) {
-                                if (dp->d_name[0] != '.') {
-                                        gchar *theme_dir;
-					gchar *theme_name;
+    if (!g_settings_is_writable (eyes_applet->settings, "theme-path")) {
+        gtk_widget_set_sensitive (tree, FALSE);
+        gtk_widget_set_sensitive (label, FALSE);
+    }
+
+    for (i = 0; i < NUM_THEME_DIRECTORIES; i++) {
+        if ((dfd = opendir (theme_directories[i])) != NULL) {
+            while ((dp = readdir (dfd)) != NULL) {
+                if (dp->d_name[0] != '.') {
+                    gchar *theme_dir;
+                    gchar *theme_name;
 #ifdef PATH_MAX
-                                        strcpy (filename,
-                                                theme_directories[i]);
-                                        strcat (filename, dp->d_name);
+                    strcpy (filename, theme_directories[i]);
+                    strcat (filename, dp->d_name);
 #else
-					asprintf (&filename, theme_directories[i], dp->d_name);
+                    asprintf (&filename, theme_directories[i], dp->d_name);
 #endif
-					theme_dir = g_strdup_printf ("%s/", filename);
-					theme_name = g_path_get_basename (filename);
+                    theme_dir = g_strdup_printf ("%s/", filename);
+                    theme_name = g_path_get_basename (filename);
 
-                                        gtk_list_store_append (model, &iter);
-                                        gtk_list_store_set (model, &iter,
-							    COL_THEME_DIR, &filename,
-							    COL_THEME_NAME, theme_name,
-							    -1);
+                    gtk_list_store_append (model, &iter);
+                    gtk_list_store_set (model, &iter, COL_THEME_DIR, &filename,
+                                        COL_THEME_NAME,
+                                        theme_name, -1);
 
-					if (!g_ascii_strncasecmp (eyes_applet->theme_dir, theme_dir, strlen (theme_dir))) {
-                                        	GtkTreePath *path;
-                                        	path = gtk_tree_model_get_path (GTK_TREE_MODEL (model),
-                                                        			&iter);
-                                                gtk_tree_view_set_cursor (GTK_TREE_VIEW (tree),
-                                                			  path,
-                                                			  NULL,
-                                                			  FALSE);
-                                                gtk_tree_path_free (path);
-                                        }
-					g_free (theme_name);
-                                        g_free (theme_dir);
-                                }
-                        }
-                        closedir (dfd);
+                    if (!g_ascii_strncasecmp (eyes_applet->theme_dir, theme_dir,
+                                              strlen (theme_dir))) {
+                        GtkTreePath *path;
+                        path = gtk_tree_model_get_path (GTK_TREE_MODEL (model),
+                                                        &iter);
+                        gtk_tree_view_set_cursor (GTK_TREE_VIEW (tree), path, NULL,
+                                                  FALSE);
+                        gtk_tree_path_free (path);
+                    }
+                    g_free (theme_name);
+                    g_free (theme_dir);
                 }
+            }
+            closedir (dfd);
         }
+    }
 #ifndef PATH_MAX
-	g_free (filename);
+    g_free (filename);
 #endif
-	g_object_unref (model);
+    g_object_unref (model);
 
-	/* signals */
-	gtk_builder_add_callback_symbols (builder,
-	                                  "on_preferences_dialog_response", G_CALLBACK (presponse_cb),
-	                                  "on_themes_treeselection_changed", G_CALLBACK (theme_selected_cb),
-	                                  NULL);
-	gtk_builder_connect_signals (builder, eyes_applet);
+    /* signals */
+    gtk_builder_add_callback_symbols (builder, "on_preferences_dialog_response",
+                                      G_CALLBACK (presponse_cb),
+                                      "on_themes_treeselection_changed",
+                                      G_CALLBACK (theme_selected_cb),
+                                      NULL);
+    gtk_builder_connect_signals (builder, eyes_applet);
 
-	g_object_unref (builder);
+    g_object_unref (builder);
 
-	gtk_widget_show_all (eyes_applet->prop_box.pbox);
+    gtk_widget_show_all (eyes_applet->prop_box.pbox);
 
-	return;
+    return;
 }

--- a/geyes/src/themes.c
+++ b/geyes/src/themes.c
@@ -210,7 +210,9 @@ theme_selected_cb (GtkTreeSelection *selection,
     load_theme (eyes_applet, theme);
     setup_eyes (eyes_applet);
 
-    g_settings_set_string (eyes_applet->settings, "theme-path", theme);
+    g_settings_set_string (eyes_applet->settings,
+                           GEYES_SETTINGS_THEME_PATH_KEY,
+                           theme);
 
     g_free (theme);
 }
@@ -300,7 +302,7 @@ properties_cb (GtkAction  *action,
                                                        NULL);
     gtk_tree_view_append_column (GTK_TREE_VIEW (tree), column);
 
-    if (!g_settings_is_writable (eyes_applet->settings, "theme-path")) {
+    if (!g_settings_is_writable (eyes_applet->settings, GEYES_SETTINGS_THEME_PATH_KEY)) {
         gtk_widget_set_sensitive (tree, FALSE);
         gtk_widget_set_sensitive (label, FALSE);
     }


### PR DESCRIPTION
- Use g_debug instead of printf for logging
- Do not store folder separator at the end of theme_dir
- Use g_build_filename instead of g_strdup_printf
- Remove trailing white spaces
- Do not use tabs for code indent