### PR TITLE
trashapplet: Remove warning about missing initializer

### DIFF
--- a/trashapplet/src/trashapplet.c
+++ b/trashapplet/src/trashapplet.c
@@ -211,7 +211,7 @@ trash_applet_dispose (GObject *object)
 static void
 trash_applet_init (TrashApplet *applet)
 {
-  const GtkTargetEntry drop_types[] = { { "text/uri-list" } };
+  const GtkTargetEntry drop_types[] = { { "text/uri-list", 0, 0 } };
 
   /* needed to clamp ourselves to the panel size */
   mate_panel_applet_set_flags (MATE_PANEL_APPLET (applet), MATE_PANEL_APPLET_EXPAND_MINOR);

--- a/trashapplet/src/xstuff.c
+++ b/trashapplet/src/xstuff.c
@@ -42,7 +42,7 @@ draw_zoom_animation (GdkScreen *gscreen,
 	int i, j;
 	GC frame_gc;
 	XGCValues gcv;
-	GdkColor color = { 65535, 65535, 65535 };
+	GdkColor color = { 0, 65535, 65535, 65535 };
 	Display *dpy;
 	Window root_win;
 	int screen;


### PR DESCRIPTION
```
trashapplet.c:214:3: warning: missing initializer for field 'flags' of 'GtkTargetEntry' {aka 'const struct _GtkTargetEntry'} [-Wmissing-field-initializers]
  214 |   const GtkTargetEntry drop_types[] = { { "text/uri-list" } };
      |   ^~~~~
--
xstuff.c:45:2: warning: missing initializer for field 'blue' of 'GdkColor' {aka 'struct _GdkColor'} [-Wmissing-field-initializers]
   45 |  GdkColor color = { 65535, 65535, 65535 };
      |  ^~~~~~~~
```