### PR TITLE
geyes: signal 'dispose' is invalid for instance 'ID' of type 'GtkBox'

### DIFF
--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -291,7 +291,7 @@ create_eyes (MatePanelApplet *applet)
 }
 
 static void
-dispose_cb (GObject *object, EyesApplet *eyes_applet)
+destroy_cb (GObject *object, EyesApplet *eyes_applet)
 {
 	g_return_if_fail (eyes_applet);
 
@@ -422,8 +422,8 @@ geyes_applet_fill (MatePanelApplet *applet)
 			_("The eyes look in the direction of the mouse pointer"));
 
 	g_signal_connect (eyes_applet->vbox,
-			  "dispose",
-			  G_CALLBACK (dispose_cb),
+			  "destroy",
+			  G_CALLBACK (destroy_cb),
 			  eyes_applet);
 
 	gtk_widget_show_all (GTK_WIDGET (eyes_applet->applet));


### PR DESCRIPTION
```
$ LANG=C journalctl --no-pager --boot | grep dispose
Nov 27 21:49:40 localhost.localdomain mate-geyes-appl[1583]: ../gobject/gsignal.c:2613: signal 'dispose' is invalid for instance '0x1f2c1b0' of type 'GtkBox'
```