### PR TITLE
geyes: Remove conversion warnings

### DIFF
--- a/geyes/src/geyes.h
+++ b/geyes/src/geyes.h
@@ -54,7 +54,7 @@ typedef struct
     gchar           *theme_name;
     gchar           *eye_filename;
     gchar           *pupil_filename;
-    gint             num_eyes;
+    gsize            num_eyes;
     gint             eye_height;
     gint             eye_width;
     gint             pupil_height;

--- a/geyes/src/themes.c
+++ b/geyes/src/themes.c
@@ -73,7 +73,7 @@ parse_theme_file (EyesApplet *eyes_applet,
             while (!isdigit (*token)) {
                 token++;
             }
-            sscanf (token, "%d", &eyes_applet->num_eyes);
+            sscanf (token, "%" G_GSIZE_FORMAT, &eyes_applet->num_eyes);
             if (eyes_applet->num_eyes > MAX_EYES)
                 eyes_applet->num_eyes = MAX_EYES;
         } else if (strncmp (token, "eye-pixmap", strlen ("eye-pixmap")) == 0) {


### PR DESCRIPTION
```
geyes.c:70:54: warning: conversion from ‘int’ to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   70 |     nx = x - MAX (width - eyes_applet->eye_width, 0) * xalign
      |                                                      ^
geyes.c:70:12: warning: conversion from ‘gint’ {aka ‘int’} to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   70 |     nx = x - MAX (width - eyes_applet->eye_width, 0) * xalign
      |            ^
geyes.c:71:10: warning: conversion from ‘int’ to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   71 |          - eyes_applet->eye_width / 2;
      |          ^
geyes.c:72:56: warning: conversion from ‘int’ to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   72 |     ny = y - MAX (height - eyes_applet->eye_height, 0) * yalign
      |                                                        ^
geyes.c:72:12: warning: conversion from ‘gint’ {aka ‘int’} to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   72 |     ny = y - MAX (height - eyes_applet->eye_height, 0) * yalign
      |            ^
geyes.c:73:10: warning: conversion from ‘int’ to ‘gfloat’ {aka ‘float’} may change value [-Wconversion]
   73 |          - eyes_applet->eye_height / 2;
      |          ^
geyes.c:82:20: warning: conversion from ‘double’ to ‘gint’ {aka ‘int’} may change value [-Wfloat-conversion]
   82 |         *pupil_x = nx + eyes_applet->eye_width / 2;
      |                    ^~
geyes.c:83:20: warning: conversion from ‘double’ to ‘gint’ {aka ‘int’} may change value [-Wfloat-conversion]
   83 |         *pupil_y = ny + eyes_applet->eye_height / 2;
      |                    ^~
geyes.c:97:16: warning: conversion from ‘double’ to ‘gint’ {aka ‘int’} may change value [-Wfloat-conversion]
   97 |     *pupil_x = temp * sina + (eyes_applet->eye_width / 2);
      |                ^~~~
geyes.c:98:16: warning: conversion from ‘double’ to ‘gint’ {aka ‘int’} may change value [-Wfloat-conversion]
   98 |     *pupil_y = temp * cosa + (eyes_applet->eye_height / 2);
      |                ^~~~
--
geyes.c:230:57: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  230 |     eyes_applet->eyes = g_new0 (GtkWidget *, eyes_applet->num_eyes);
/usr/include/glib-2.0/glib/gmem.h:261:41: note: in definition of macro ‘_G_NEW’
--
geyes.c:231:60: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  231 |     eyes_applet->pointer_last_x = g_new0 (gint, eyes_applet->num_eyes);
/usr/include/glib-2.0/glib/gmem.h:261:41: note: in definition of macro ‘_G_NEW’
--
geyes.c:232:60: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  232 |     eyes_applet->pointer_last_y = g_new0 (gint, eyes_applet->num_eyes);
```