### PR TITLE
mateweather: Remove conversion warnings

### DIFF
--- a/mateweather/src/mateweather-applet.c
+++ b/mateweather/src/mateweather-applet.c
@@ -128,7 +128,7 @@ place_widgets (MateWeatherApplet *gw_applet)
     GtkRequisition req;
     int total_size = 0;
     gboolean horizontal = FALSE;
-    int panel_size = gw_applet->size;
+    int panel_size = (int) gw_applet->size;
     const gchar *temp = NULL;
     const gchar *icon_name = NULL;
 
@@ -208,20 +208,24 @@ static void change_orient_cb (MatePanelApplet *w, MatePanelAppletOrient o, gpoin
 
 static void size_allocate_cb(MatePanelApplet *w, GtkAllocation *allocation, gpointer data)
 {
+    guint size;
     MateWeatherApplet *gw_applet = (MateWeatherApplet *)data;
 
-    if ((gw_applet->orient == MATE_PANEL_APPLET_ORIENT_LEFT) || (gw_applet->orient == MATE_PANEL_APPLET_ORIENT_RIGHT)) {
-      if (gw_applet->size == allocation->width)
-	return;
-      gw_applet->size = allocation->width;
-    } else {
-      if (gw_applet->size == allocation->height)
-	return;
-      gw_applet->size = allocation->height;
+    switch (gw_applet->orient) {
+      case MATE_PANEL_APPLET_ORIENT_LEFT:
+      case MATE_PANEL_APPLET_ORIENT_RIGHT:
+        size = (guint) allocation->width;
+        break;
+
+      default:
+        size = (guint) allocation->height;
     }
 
-    place_widgets(gw_applet);
-    return;
+    if (gw_applet->size == size)
+      return;
+
+    gw_applet->size = size;
+    place_widgets (gw_applet);
 }
 
 static gboolean clicked_cb (GtkWidget *widget, GdkEventButton *ev, gpointer data)
@@ -294,13 +298,13 @@ applet_destroy (GtkWidget *widget, MateWeatherApplet *gw_applet)
     if (gw_applet->details_dialog)
        gtk_widget_destroy (gw_applet->details_dialog);
 
-    if (gw_applet->timeout_tag > 0) {
-       g_source_remove(gw_applet->timeout_tag);
+    if (gw_applet->timeout_tag != 0) {
+       g_source_remove (gw_applet->timeout_tag);
        gw_applet->timeout_tag = 0;
     }
 
-    if (gw_applet->suncalc_timeout_tag > 0) {
-       g_source_remove(gw_applet->suncalc_timeout_tag);
+    if (gw_applet->suncalc_timeout_tag != 0) {
+       g_source_remove (gw_applet->suncalc_timeout_tag);
        gw_applet->suncalc_timeout_tag = 0;
     }
 
@@ -410,13 +414,13 @@ update_finish (WeatherInfo *info, gpointer data)
         gint nxtSunEvent;
 
         gw_applet->timeout_tag
-            = g_timeout_add_seconds (gw_applet->mateweather_pref.update_interval,
+            = g_timeout_add_seconds ((guint) gw_applet->mateweather_pref.update_interval,
                                      timeout_cb, gw_applet);
 
         if ((info != NULL) && ((nxtSunEvent = weather_info_next_sun_event (info)) >= 0))
         {
             gw_applet->suncalc_timeout_tag
-                = g_timeout_add_seconds (nxtSunEvent,
+                = g_timeout_add_seconds ((guint) nxtSunEvent,
                                          suncalc_timeout_cb, gw_applet);
         }
     }

--- a/mateweather/src/mateweather-pref.c
+++ b/mateweather/src/mateweather-pref.c
@@ -170,13 +170,17 @@ static gboolean update_dialog(MateWeatherPref* pref)
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(pref->priv->basic_update_btn), gw_applet->mateweather_pref.update_enabled);
     soft_set_sensitive(pref->priv->basic_update_spin, gw_applet->mateweather_pref.update_enabled);
 
-    gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_temp_combo), gw_applet->mateweather_pref.temperature_unit - 2);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (pref->priv->basic_temp_combo),
+                              (gint) gw_applet->mateweather_pref.temperature_unit - 2);
 
-    gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_speed_combo), gw_applet->mateweather_pref.speed_unit - 2);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (pref->priv->basic_speed_combo),
+                              (gint) gw_applet->mateweather_pref.speed_unit - 2);
 
-    gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_pres_combo), gw_applet->mateweather_pref.pressure_unit - 2);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (pref->priv->basic_pres_combo),
+                              (gint) gw_applet->mateweather_pref.pressure_unit - 2);
 
-    gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_dist_combo), gw_applet->mateweather_pref.distance_unit - 2);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (pref->priv->basic_dist_combo),
+                              (gint) gw_applet->mateweather_pref.distance_unit - 2);
 
 	#ifdef RADARMAP
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(pref->priv->basic_radar_btn), gw_applet->mateweather_pref.radar_enabled);
@@ -335,12 +339,16 @@ on_auto_update_toggled (GtkToggleButton *button,
 
 	if (gw_applet->mateweather_pref.update_enabled)
 	{
-		gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
-		nxtSunEvent = weather_info_next_sun_event(gw_applet->mateweather_info);
+		gw_applet->timeout_tag
+			= g_timeout_add_seconds ((guint) gw_applet->mateweather_pref.update_interval,
+		                                 timeout_cb, gw_applet);
 
+		nxtSunEvent = weather_info_next_sun_event (gw_applet->mateweather_info);
 		if (nxtSunEvent >= 0)
 		{
-			gw_applet->suncalc_timeout_tag = g_timeout_add_seconds(nxtSunEvent, suncalc_timeout_cb, gw_applet);
+			gw_applet->suncalc_timeout_tag
+				= g_timeout_add_seconds ((guint) nxtSunEvent,
+				                         suncalc_timeout_cb, gw_applet);
 		}
 	}
 }
@@ -536,7 +544,9 @@ on_update_interval_changed (GtkSpinButton   *button,
 
 	if (gw_applet->mateweather_pref.update_enabled)
 	{
-		gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
+		gw_applet->timeout_tag
+			= g_timeout_add_seconds ((guint) gw_applet->mateweather_pref.update_interval,
+			                         timeout_cb, gw_applet);
 	}
 }
 
@@ -592,14 +602,10 @@ static gboolean find_location(GtkTreeModel* model, GtkTreeIter* iter, const gcha
 	GtkTreeIter iter_parent;
 	gchar* aux_loc;
 	gboolean valid;
-	int len;
+	size_t len;
 
-	len = strlen (location);
-
-	if (len <= 0)
-	{
+	if ((len = strlen (location)) == 0)
 		return FALSE;
-	}
 
 	do {
 

--- a/mateweather/src/mateweather.h
+++ b/mateweather/src/mateweather.h
@@ -35,9 +35,9 @@ typedef struct _MateWeatherApplet {
 	GtkWidget* image;
 
 	MatePanelAppletOrient orient;
-	gint size;
-	gint timeout_tag;
-	gint suncalc_timeout_tag;
+	guint size;
+	guint timeout_tag;
+	guint suncalc_timeout_tag;
 
 	/* preferences  */
 	MateWeatherPrefs mateweather_pref;


### PR DESCRIPTION
```
mateweather-pref.c:173:120: warning: conversion to ‘gint’ {aka ‘int’} from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
  173 |     gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_temp_combo), gw_applet->mateweather_pref.temperature_unit - 2);
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
mateweather-pref.c:175:115: warning: conversion to ‘gint’ {aka ‘int’} from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
  175 |     gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_speed_combo), gw_applet->mateweather_pref.speed_unit - 2);
      |                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
mateweather-pref.c:177:117: warning: conversion to ‘gint’ {aka ‘int’} from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
  177 |     gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_pres_combo), gw_applet->mateweather_pref.pressure_unit - 2);
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
mateweather-pref.c:179:117: warning: conversion to ‘gint’ {aka ‘int’} from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
  179 |     gtk_combo_box_set_active(GTK_COMBO_BOX(pref->priv->basic_dist_combo), gw_applet->mateweather_pref.distance_unit - 2);
      |                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
--
mateweather-pref.c:328:28: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  328 |   g_source_remove(gw_applet->timeout_tag);
      |                   ~~~~~~~~~^~~~~~~~~~~~~
mateweather-pref.c:333:28: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  333 |   g_source_remove(gw_applet->suncalc_timeout_tag);
      |                   ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
mateweather-pref.c:338:77: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  338 |   gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
mateweather-pref.c:338:28: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  338 |   gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
      |                            ^~~~~~~~~~~~~~~~~~~~~
mateweather-pref.c:343:59: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  343 |    gw_applet->suncalc_timeout_tag = g_timeout_add_seconds(nxtSunEvent, suncalc_timeout_cb, gw_applet);
      |                                                           ^~~~~~~~~~~
mateweather-pref.c:343:37: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  343 |    gw_applet->suncalc_timeout_tag = g_timeout_add_seconds(nxtSunEvent, suncalc_timeout_cb, gw_applet);
      |                                     ^~~~~~~~~~~~~~~~~~~~~
--
mateweather-pref.c:534:28: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  534 |   g_source_remove(gw_applet->timeout_tag);
      |                   ~~~~~~~~~^~~~~~~~~~~~~
mateweather-pref.c:539:77: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  539 |   gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
mateweather-pref.c:539:28: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  539 |   gw_applet->timeout_tag = g_timeout_add_seconds(gw_applet->mateweather_pref.update_interval, timeout_cb, gw_applet);
      |                            ^~~~~~~~~~~~~~~~~~~~~
--
mateweather-pref.c:597:8: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  597 |  len = strlen (location);
      |        ^~~~~~
mateweather-pref.c:608:47: warning: conversion to ‘gsize’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
  608 |   if (g_ascii_strncasecmp (aux_loc, location, len) == 0)
      |                                               ^~~
--
mateweather-applet.c:298:33: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  298 |        g_source_remove(gw_applet->timeout_tag);
      |                        ~~~~~~~~~^~~~~~~~~~~~~
mateweather-applet.c:303:33: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  303 |        g_source_remove(gw_applet->suncalc_timeout_tag);
      |                        ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
--
mateweather-applet.c:360:23: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  360 |     gw_applet->size = mate_panel_applet_get_size (gw_applet->applet);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
--
mateweather-applet.c:407:34: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  407 |         g_source_remove(gw_applet->timeout_tag);
      |                         ~~~~~~~~~^~~~~~~~~~~~~
mateweather-applet.c:413:65: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  413 |             = g_timeout_add_seconds (gw_applet->mateweather_pref.update_interval,
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
mateweather-applet.c:413:15: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  413 |             = g_timeout_add_seconds (gw_applet->mateweather_pref.update_interval,
      |               ^~~~~~~~~~~~~~~~~~~~~
mateweather-applet.c:419:42: warning: conversion to ‘guint’ {aka ‘unsigned int’} from ‘gint’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
  419 |                 = g_timeout_add_seconds (nxtSunEvent,
      |                                          ^~~~~~~~~~~
mateweather-applet.c:419:19: warning: conversion to ‘gint’ {aka ‘int’} from ‘guint’ {aka ‘unsigned int’} may change the sign of the result [-Wsign-conversion]
  419 |                 = g_timeout_add_seconds (nxtSunEvent,
      |                   ^~~~~~~~~~~~~~~~~~~~~
```