### PR TITLE
netspeed: improve display of IPv6 addresses in device details.

### DIFF
--- a/netspeed/data/netspeed-details.ui
+++ b/netspeed/data/netspeed-details.ui
@@ -250,6 +250,48 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkBox" id="ipv6_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="ipv6_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">IPv6 Address:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="ipv6_text">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="selectable">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -314,7 +356,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -376,48 +418,6 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">3</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="ipv6_box">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="ipv6_label">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">IPv6 Address:</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="ipv6_text">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="selectable">True</property>
-                        <property name="xalign">0</property>
-                        <property name="yalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>

--- a/netspeed/src/backend.c
+++ b/netspeed/src/backend.c
@@ -174,8 +174,8 @@ get_ip_address_list (const char *iface_name,
                     }
 
                     list = g_slist_prepend (list,
-                                            g_strdup_printf ("%s: %s/%u",
-                                                             scope, ip, netmask));
+                                            g_strdup_printf ("%s/%u (%s)",
+                                                             ip, netmask, scope));
                 } else {
                     struct sockaddr_in ip4_addr;
                     struct sockaddr_in ip4_network;


### PR DESCRIPTION
![Device-details](https://user-images.githubusercontent.com/26790192/102837389-fae38880-43fb-11eb-8192-465d40a56412.png)

I think IPv6 address box should go directly below IPv4 as IPv6 is the new standard.

Also, I think it looks better and more meaningful if address scope is added to the back of the address in brackets, not in front. This is also more consistent with display of IPv4 addresses.