### PR TITLE
netspeed-preferences: disconnect a signal handler on finalize

### DIFF
--- a/netspeed/src/netspeed-preferences.c
+++ b/netspeed/src/netspeed-preferences.c
@@ -55,12 +55,6 @@ netspeed_preferences_init (NetspeedPreferences *preferences)
 }
 
 static void
-netspeed_preferences_finalize (GObject *object)
-{
-  G_OBJECT_CLASS (netspeed_preferences_parent_class)->finalize (object);
-}
-
-static void
 netspeed_preferences_set_property (GObject      *object,
                                    guint         property_id,
                                    const GValue *value,
@@ -148,6 +142,16 @@ on_network_device_combo_changed (GtkComboBox         *combo,
   if (old_auto_change_device != auto_change_device)
     g_settings_set_boolean (preferences->settings,
                             "auto-change-device", auto_change_device);
+}
+
+static void
+netspeed_preferences_finalize (GObject *object)
+{
+  NetspeedPreferences *self = NETSPEED_PREFERENCES (object);
+  g_signal_handlers_disconnect_by_func (self->network_device_combo,
+                                        on_network_device_combo_changed,
+                                        self);
+  G_OBJECT_CLASS (netspeed_preferences_parent_class)->finalize (object);
 }
 
 static void


### PR DESCRIPTION
```
systemd-coredump[137882]: [LNK] Process 137875 (mate-netspeed-a) of user 1000 dumped core.
                                                                
                                                                Stack trace of thread 137875:
                                                                #0  0x000000000040dafe on_network_device_combo_changed (mate-netspeed-applet + 0xdafe)
                                                                #1  0x00007fd8358316a9 _g_closure_invoke_va (libgobject-2.0.so.0 + 0x146a9)
                                                                #2  0x00007fd8358493a8 g_signal_emit_valist (libgobject-2.0.so.0 + 0x2c3a8)
                                                                #3  0x00007fd835849582 g_signal_emit (libgobject-2.0.so.0 + 0x2c582)
                                                                #4  0x00007fd83635fd65 gtk_combo_box_set_active_internal.lto_priv.0 (libgtk-3.so.0 + 0x173d65)
                                                                #5  0x00007fd836360113 gtk_combo_box_set_active (libgtk-3.so.0 + 0x174113)
                                                                #6  0x000000000040de9f fill_device_combo (mate-netspeed-applet + 0xde9f)
                                                                #7  0x000000000040df41 netspeed_preferences_new (mate-netspeed-applet + 0xdf41)
                                                                #8  0x000000000040b5de settings_cb (mate-netspeed-applet + 0xb5de)
                                                                #9  0x00007fd83583147f g_closure_invoke (libgobject-2.0.so.0 + 0x1447f)
                                                                #10 0x00007fd835842e4b signal_emit_unlocked_R (libgobject-2.0.so.0 + 0x25e4b)
                                                                #11 0x00007fd83584907b g_signal_emit_valist (libgobject-2.0.so.0 + 0x2c07b)
                                                                #12 0x00007fd835849582 g_signal_emit (libgobject-2.0.so.0 + 0x2c582)
                                                                #13 0x00007fd8362a2e3f _gtk_action_emit_activate (libgtk-3.so.0 + 0xb6e3f)
                                                                #14 0x00007fd8358316a9 _g_closure_invoke_va (libgobject-2.0.so.0 + 0x146a9)
                                                                #15 0x00007fd8358493a8 g_signal_emit_valist (libgobject-2.0.so.0 + 0x2c3a8)
                                                                #16 0x00007fd835849582 g_signal_emit (libgobject-2.0.so.0 + 0x2c582)
                                                                #17 0x00007fd8365913dc gtk_widget_activate (libgtk-3.so.0 + 0x3a53dc)
                                                                #18 0x00007fd8364590fe gtk_menu_shell_activate_item (libgtk-3.so.0 + 0x26d0fe)
                                                                #19 0x00007fd836459483 gtk_menu_shell_button_release (libgtk-3.so.0 + 0x26d483)
                                                                #20 0x00007fd8365e1ccc _gtk_marshal_BOOLEAN__BOXEDv (libgtk-3.so.0 + 0x3f5ccc)
                                                                #21 0x00007fd8358316a9 _g_closure_invoke_va (libgobject-2.0.so.0 + 0x146a9)
                                                                #22 0x00007fd835848758 g_signal_emit_valist (libgobject-2.0.so.0 + 0x2b758)
                                                                #23 0x00007fd835849582 g_signal_emit (libgobject-2.0.so.0 + 0x2c582)
                                                                #24 0x00007fd8365a4bb4 gtk_widget_event_internal.part.0.lto_priv.0 (libgtk-3.so.0 + 0x3b8bb4)
                                                                #25 0x00007fd836442f50 propagate_event.lto_priv.0 (libgtk-3.so.0 + 0x256f50)
                                                                #26 0x00007fd836444223 gtk_main_do_event (libgtk-3.so.0 + 0x258223)
                                                                #27 0x00007fd836120633 _gdk_event_emit (libgdk-3.so.0 + 0x38633)
                                                                #28 0x00007fd836158466 gdk_event_source_dispatch (libgdk-3.so.0 + 0x70466)
                                                                #29 0x00007fd83574065b g_main_dispatch (libglib-2.0.so.0 + 0x5065b)
                                                                #30 0x00007fd8357408d8 g_main_context_iterate (libglib-2.0.so.0 + 0x508d8)
                                                                #31 0x00007fd835740bbb g_main_loop_run (libglib-2.0.so.0 + 0x50bbb)
                                                                #32 0x00007fd83643f7ad gtk_main (libgtk-3.so.0 + 0x2537ad)
                                                                #33 0x00007fd8369a7973 _mate_panel_applet_factory_main_internal (libmate-panel-applet-4.so.1 + 0xc973)
                                                                #34 0x00007fd8369a79d1 mate_panel_applet_factory_main (libmate-panel-applet-4.so.1 + 0xc9d1)
                                                                #35 0x000000000040d634 main (mate-netspeed-applet + 0xd634)
                                                                #36 0x00007fd8353d91e2 __libc_start_main (libc.so.6 + 0x281e2)
                                                                #37 0x0000000000405dfe _start (mate-netspeed-applet + 0x5dfe)
                                                                
                                                                Stack trace of thread 137878:
                                                                #0  0x00007fd8354a780f __poll (libc.so.6 + 0xf680f)
                                                                #1  0x00007fd835740876 g_main_context_poll (libglib-2.0.so.0 + 0x50876)
                                                                #2  0x00007fd835740bbb g_main_loop_run (libglib-2.0.so.0 + 0x50bbb)
                                                                #3  0x00007fd83598ba46 gdbus_shared_thread_func (libgio-2.0.so.0 + 0x115a46)
                                                                #4  0x00007fd835768d1d g_thread_proxy (libglib-2.0.so.0 + 0x78d1d)
                                                                #5  0x00007fd835e4a3f9 start_thread (libpthread.so.0 + 0x93f9)
                                                                #6  0x00007fd8354b2903 __clone (libc.so.6 + 0x101903)
                                                                
                                                                Stack trace of thread 137879:
                                                                #0  0x00007fd8354ad30d syscall (libc.so.6 + 0xfc30d)
                                                                #1  0x00007fd835790842 g_cond_wait_until (libglib-2.0.so.0 + 0xa0842)
                                                                #2  0x00007fd835711541 g_async_queue_pop_intern_unlocked (libglib-2.0.so.0 + 0x21541)
                                                                #3  0x00007fd835711b22 g_async_queue_timeout_pop (libglib-2.0.so.0 + 0x21b22)
                                                                #4  0x00007fd835769649 g_thread_pool_wait_for_new_pool (libglib-2.0.so.0 + 0x79649)
                                                                #5  0x00007fd835768d1d g_thread_proxy (libglib-2.0.so.0 + 0x78d1d)
                                                                #6  0x00007fd835e4a3f9 start_thread (libpthread.so.0 + 0x93f9)
                                                                #7  0x00007fd8354b2903 __clone (libc.so.6 + 0x101903)
                                                                
                                                                Stack trace of thread 137877:
                                                                #0  0x00007fd8354a780f __poll (libc.so.6 + 0xf680f)
                                                                #1  0x00007fd835740876 g_main_context_poll (libglib-2.0.so.0 + 0x50876)
                                                                #2  0x00007fd83574097f g_main_context_iteration (libglib-2.0.so.0 + 0x5097f)
                                                                #3  0x00007fd8357409d1 glib_worker_main (libglib-2.0.so.0 + 0x509d1)
                                                                #4  0x00007fd835768d1d g_thread_proxy (libglib-2.0.so.0 + 0x78d1d)
                                                                #5  0x00007fd835e4a3f9 start_thread (libpthread.so.0 + 0x93f9)
                                                                #6  0x00007fd8354b2903 __clone (libc.so.6 + 0x101903)
                                                                
                                                                Stack trace of thread 137880:
                                                                #0  0x00007fd8354a780f __poll (libc.so.6 + 0xf680f)
                                                                #1  0x00007fd835740876 g_main_context_poll (libglib-2.0.so.0 + 0x50876)
                                                                #2  0x00007fd83574097f g_main_context_iteration (libglib-2.0.so.0 + 0x5097f)
                                                                #3  0x00007fd82745864d dconf_gdbus_worker_thread (libdconfsettings.so + 0x664d)
                                                                #4  0x00007fd835768d1d g_thread_proxy (libglib-2.0.so.0 + 0x78d1d)
                                                                #5  0x00007fd835e4a3f9 start_thread (libpthread.so.0 + 0x93f9)
                                                                #6  0x00007fd8354b2903 __clone (libc.so.6 + 0x101903)
...
abrt-notification[137936]: [LNK] Process 13438 (mate-netspeed-applet) crashed in on_network_device_combo_changed()
