### PR TITLE
netspeed: Remove -Wunused-variable warning

### DIFF
--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -1564,7 +1564,6 @@ device_settings_changed (GSettings      *settings,
                          NetspeedApplet *netspeed)
 {
     char *device;
-    DevInfo *info;
 
     device = g_settings_get_string (settings, key);
     free_device_info (netspeed->devinfo);


### PR DESCRIPTION
```
netspeed.c:1567:14: warning: unused variable ‘info’ [-Wunused-variable]
 1567 |     DevInfo *info;
      |              ^~~~
```