### PR TITLE
multiload: fix netspeed_add signature

### DIFF
--- a/multiload/src/netspeed.h
+++ b/multiload/src/netspeed.h
@@ -9,7 +9,7 @@ typedef struct _NetSpeed NetSpeed;
 
 NetSpeed* netspeed_new(LoadGraph *graph);
 void netspeed_delete(NetSpeed *ns);
-void netspeed_add(NetSpeed *ns, gulong tx);
+void netspeed_add(NetSpeed *ns, guint64 tx);
 char* netspeed_get(NetSpeed *ns);
 
 #endif /* H_MULTILOAD_NETSPEED_ */


### PR DESCRIPTION
Commit c85a5cf5 changed the definition to use guint64 rather than
gulong, but did not update the declaration in netspeed.h to match.