### PR TITLE
cpufreq: fix cpufreq-selector-sysfs duplicate definitions

### DIFF
--- a/cpufreq/src/cpufreq-selector/Makefile.am
+++ b/cpufreq/src/cpufreq-selector/Makefile.am
@@ -21,7 +21,6 @@ endif
 
 mate_cpufreq_selector_SOURCES = \
 	cpufreq-selector.c               cpufreq-selector.h        	\
-	cpufreq-selector-sysfs.c         cpufreq-selector-sysfs.h  	\
 	$(service_files)						\
 	cpufreq-selector-factory.c	 cpufreq-selector-factory.h	\
 	$(BUILT_SOURCES)						\


### PR DESCRIPTION
Commit 4cb6f915 added cpufreq-selector-sysfs.[ch] to
mate_cpufreq_selector_SOURCES for the !HAVE_LIBCPUFREQ case, but they
were already unconditionally part of that. Including them twice leads to
duplicate definitions for the symbols defined by them.