### PR TITLE
build: underline package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -621,7 +621,10 @@ dnl ***************************************************************************
 dnl *** Display Summary                                                     ***
 dnl ***************************************************************************
 echo "
-mate-applets-$VERSION configure summary:
+Configure summary:
+
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
     Prefix:                        ${prefix}
     Source code location:          ${srcdir}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

    mate-applets 1.25.3
    ===================

    Prefix:                        /usr
    Source code location:          .
    Compiler:                      gcc
    Compiler flags:                -g -O2
    Compiler warnings:             -Wall -Wmissing-prototypes

    Building:
        - accessx-status           true
        - battstat                 yes
        - charpick                 always
            - gucharmap support    yes
        - cpufreq                  yes
            - building selector    yes
            - using PolicyKit      yes
            - enabling suid bit    no
        - drivemount               always
        - geyes                    always
        - mateweather              true
        - multiload                true
        - netspeed                 true
            - iwlib support        no
            - netfilter support    yes
        - stickynotes              yes
        - timerapplet              yes
        - trashapplet              always

    Using DBUS:                    yes
    Using UPOWER:                  yes
    Using libnotify:               yes
    Enabling IPv6:                 yes

Now type `make' to compile mate-applets
```