### PR TITLE
Fix #372 by using GtkInvisible widget

### DIFF
--- a/charpick/charpick.h
+++ b/charpick/charpick.h
@@ -22,6 +22,7 @@ struct _charpick_data {
     GtkWidget       *box;
     GtkWidget       *frame;
     GtkWidget       *applet;
+    GtkWidget       *invisible;
     GtkToggleButton *last_toggle_button;
     gint             panel_size;
     gboolean         panel_vertical;
@@ -32,6 +33,7 @@ struct _charpick_data {
     GtkWidget       *add_edit_dialog;
     GtkWidget       *add_edit_entry;
     GSettings       *settings;
+    guint           rebuild_id;
 };
 
 typedef struct _charpick_button_cb_data charpick_button_cb_data;


### PR DESCRIPTION
Applied following patches by @muktupavels

* https://gitlab.gnome.org/GNOME/gnome-applets/-/commit/36f313d880aef4df2925a1fce585fa820429d4fd
* https://gitlab.gnome.org/GNOME/gnome-applets/-/commit/19c7ccdc26094988c979fa2ee9ace315acfa9f5e