### PR TITLE
Remove callbacks for the removed sticky notes popup menu

### DIFF
--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -161,12 +161,6 @@ stickynote_new_aux (GdkScreen *screen,
     gtk_widget_set_direction (GTK_WIDGET (gtk_builder_get_object (builder, "resize_bar")),
                               GTK_TEXT_DIR_LTR);
 
-    note->w_menu = GTK_WIDGET (gtk_builder_get_object (builder,
-                                                       "stickynote_menu"));
-    note->ta_lock_toggle_item =
-        GTK_TOGGLE_ACTION (gtk_builder_get_object (builder,
-                                                   "popup_toggle_lock"));
-
     note->w_properties =
         GTK_WIDGET (gtk_builder_get_object (builder,
                                             "stickynote_properties"));
@@ -255,33 +249,6 @@ stickynote_new_aux (GdkScreen *screen,
 
     gtk_widget_realize (note->w_window);
 
-    /* Connect a popup menu to all buttons and title */
-    /* GtkBuilder holds and drops the references to all the widgets it
-     * creates for as long as it exist (GtkBuilder). Hence in our callback
-     * we would have an invalid GtkMenu. We need to ref it.
-     */
-    g_object_ref (note->w_menu);
-
-    g_signal_connect (note->w_window, "button-press-event",
-                      G_CALLBACK (stickynote_show_popup_menu),
-                      note->w_menu);
-
-    g_signal_connect (note->w_lock, "button-press-event",
-                      G_CALLBACK (stickynote_show_popup_menu),
-                      note->w_menu);
-
-    g_signal_connect (note->w_close, "button-press-event",
-                      G_CALLBACK (stickynote_show_popup_menu),
-                      note->w_menu);
-
-    g_signal_connect (note->w_resize_se, "button-press-event",
-                      G_CALLBACK (stickynote_show_popup_menu),
-                      note->w_menu);
-
-    g_signal_connect (note->w_resize_sw, "button-press-event",
-                      G_CALLBACK (stickynote_show_popup_menu),
-                      note->w_menu);
-
     /* Connect a properties dialog to the note */
     gtk_window_set_transient_for (GTK_WINDOW (note->w_properties),
                                   GTK_WINDOW (note->w_window));
@@ -318,22 +285,6 @@ stickynote_new_aux (GdkScreen *screen,
 
     g_signal_connect (note->w_window, "delete-event",
                       G_CALLBACK (stickynote_delete_cb),
-                      note);
-
-    g_signal_connect (gtk_builder_get_object (builder, "popup_create"), "activate",
-                      G_CALLBACK (popup_create_cb),
-                      note);
-
-    g_signal_connect (gtk_builder_get_object (builder, "popup_destroy"), "activate",
-                      G_CALLBACK (popup_destroy_cb),
-                      note);
-
-    g_signal_connect (gtk_builder_get_object (builder, "popup_toggle_lock"), "toggled",
-                      G_CALLBACK (popup_toggle_lock_cb),
-                      note);
-
-    g_signal_connect (gtk_builder_get_object (builder, "popup_properties"), "activate",
-                      G_CALLBACK (popup_properties_cb),
                       note);
 
     g_signal_connect_swapped (note->w_entry, "changed",
@@ -392,7 +343,6 @@ stickynote_new (GdkScreen *screen)
 void stickynote_free (StickyNote *note)
 {
     gtk_widget_destroy (note->w_properties);
-    gtk_widget_destroy (note->w_menu);
     gtk_widget_destroy (note->w_window);
 
     g_free (note->color);
@@ -710,9 +660,6 @@ stickynote_set_locked (StickyNote *note,
 
     gtk_image_set_pixel_size (note->img_lock,
                               STICKYNOTES_ICON_SIZE);
-
-    gtk_toggle_action_set_active (note->ta_lock_toggle_item,
-                                  locked);
 
     stickynotes_applet_update_menus ();
 }

--- a/stickynotes/stickynotes.h
+++ b/stickynotes/stickynotes.h
@@ -29,7 +29,6 @@
 typedef struct
 {
     GtkWidget *w_window;                  /* Sticky Note window */
-    GtkWidget *w_menu;                    /* Sticky Note menu */
     GtkWidget *w_properties;              /* Sticky Note properties dialog */
 
     GtkWidget *w_entry;                   /* Sticky Note title entry */
@@ -51,8 +50,6 @@ typedef struct
     GtkWidget *w_resize_sw;               /* Sticky Note resize button (south west) */
 
     GtkSourceBuffer *buffer;              /* Sticky Note text buffer for undo/redo */
-
-    GtkToggleAction *ta_lock_toggle_item; /* Lock item in the popup menu */
 
     GtkImage *img_lock;                   /* Lock image */
     GtkImage *img_close;                  /* Close image */

--- a/stickynotes/stickynotes_callbacks.c
+++ b/stickynotes/stickynotes_callbacks.c
@@ -108,53 +108,6 @@ stickynote_delete_cb (GtkWidget  *widget,
     return TRUE;
 }
 
-/* Sticky Window Callback : Popup the right click menu. */
-gboolean
-stickynote_show_popup_menu (GtkWidget      *widget,
-                            GdkEventButton *event,
-                            GtkWidget      *popup_menu)
-{
-    if (event->type == GDK_BUTTON_PRESS && event->button == 3) {
-        gtk_menu_popup_at_pointer (GTK_MENU (popup_menu),
-                                   (const GdkEvent*) event);
-    }
-
-    return FALSE;
-}
-
-
-/* Popup Menu Callback : Create a new sticky note */
-void popup_create_cb (GtkWidget  *widget,
-                      StickyNote *note)
-{
-    stickynotes_add (gtk_widget_get_screen (note->w_window));
-}
-
-/* Popup Menu Callback : Destroy selected sticky note */
-void
-popup_destroy_cb (GtkWidget  *widget,
-                  StickyNote *note)
-{
-    stickynotes_remove (note);
-}
-
-/* Popup Menu Callback : Lock/Unlock selected sticky note */
-void
-popup_toggle_lock_cb (GtkToggleAction *action,
-                      StickyNote      *note)
-{
-    stickynote_set_locked (note,
-                           gtk_toggle_action_get_active (action));
-}
-
-/* Popup Menu Callback : Change sticky note properties */
-void
-popup_properties_cb (GtkWidget  *widget,
-                     StickyNote *note)
-{
-    stickynote_change_properties (note);
-}
-
 /* Properties Dialog Callback : Apply title */
 void
 properties_apply_title_cb (StickyNote *note)

--- a/stickynotes/stickynotes_callbacks.h
+++ b/stickynotes/stickynotes_callbacks.h
@@ -45,24 +45,6 @@ gboolean
 stickynote_delete_cb (GtkWidget  *widget,
                       GdkEvent   *event,
                       StickyNote *note);
-gboolean
-stickynote_show_popup_menu (GtkWidget      *widget,
-                            GdkEventButton *event,
-                            GtkWidget      *popup_menu);
-
-/* Callbacks for the sticky notes popup menu */
-void
-popup_create_cb (GtkWidget  *widget,
-                 StickyNote *note);
-void
-popup_destroy_cb (GtkWidget  *widget,
-                  StickyNote *note);
-void
-popup_toggle_lock_cb (GtkToggleAction *action,
-                      StickyNote      *note);
-void
-popup_properties_cb (GtkWidget  *widget,
-                     StickyNote *note);
 
 /* Callbacks for sticky notes properties dialog */
 void


### PR DESCRIPTION
Test on Fedora:
```
CC=clang CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" ./autogen.sh --prefix=/usr --enable-debug && make &> make.log && sudo make install
```
log before PR:
```
$ LANG=C journalctl --no-pager --boot | grep stickynotes
Oct 20 14:57:00 fedora stickynotes-app[1871]: gtk_toggle_action_set_active: assertion 'GTK_IS_TOGGLE_ACTION (action)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: invalid (NULL) pointer instance
Oct 20 14:57:00 fedora stickynotes-app[1871]: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: invalid (NULL) pointer instance
Oct 20 14:57:00 fedora stickynotes-app[1871]: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: invalid (NULL) pointer instance
Oct 20 14:57:00 fedora stickynotes-app[1871]: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: invalid (NULL) pointer instance
Oct 20 14:57:00 fedora stickynotes-app[1871]: g_signal_connect_data: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
Oct 20 14:57:00 fedora stickynotes-app[1871]: gtk_toggle_action_set_active: assertion 'GTK_IS_TOGGLE_ACTION (action)' failed
```
