### PR TITLE
battstat: implicit conversion changes signedness: 'gboolean' to 'guint'

### DIFF
--- a/battstat/battstat-upower.h
+++ b/battstat/battstat-upower.h
@@ -26,6 +26,7 @@
 
 char *battstat_upower_initialise (void (*) (void));
 void battstat_upower_cleanup (void);
+void error_dialog (const char *fmt , ...);
 
 #include "battstat.h"
 void battstat_upower_get_battery_info (BatteryStatus *status);

--- a/battstat/battstat.h
+++ b/battstat/battstat.h
@@ -151,6 +151,6 @@ const char *power_management_getinfo (BatteryStatus *status);
 const char *power_management_initialise (void (*callback) (void));
 void power_management_cleanup (void);
 
-int power_management_using_upower (void);
+gboolean power_management_using_upower (void);
 
 #endif /* _battstat_h_ */

--- a/battstat/battstat.h
+++ b/battstat/battstat.h
@@ -56,13 +56,20 @@ typedef enum
   STATUS_PIXMAP_NUM
 } StatusPixmapIndex;
 
+typedef enum
+{
+  POWER_STATUS_OFF = 0,
+  POWER_STATUS_ON,
+  POWER_STATUS_UNKNOWN
+} PowerStatus;
+
 typedef struct
 {
-  gboolean on_ac_power;
-  gboolean charging;
-  gboolean present;
-  gint minutes;
-  gint percent;
+  PowerStatus on_ac_power;
+  PowerStatus charging;
+  gboolean    present;
+  gint        minutes;
+  gint        percent;
 } BatteryStatus;
 
 typedef enum
@@ -133,12 +140,12 @@ typedef struct _ProgressData {
   int timeout;
 
   /* last_* for the benefit of the check_for_updates function */
-  guint last_batt_life;
-  guint last_acline_status;
+  guint             last_batt_life;
   StatusPixmapIndex last_pixmap_index;
-  guint last_charging;
-  guint last_minutes;
-  gboolean last_present;
+  PowerStatus       last_acline_status;
+  PowerStatus       last_charging;
+  gboolean          last_present;
+  guint             last_minutes;
 } ProgressData;
 
 /* battstat_applet.c */

--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -726,10 +726,10 @@ check_for_updates (gpointer data)
         battstat->refresh_label = FALSE;
     }
 
-    battstat->last_charging = info.charging;
+    battstat->last_charging = (info.charging != FALSE);
     battstat->last_batt_life = info.percent;
     battstat->last_minutes = info.minutes;
-    battstat->last_acline_status = info.on_ac_power;
+    battstat->last_acline_status = (info.on_ac_power != FALSE);
     battstat->last_present = info.present;
 
     return TRUE;

--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -675,8 +675,7 @@ check_for_updates (gpointer data)
     }
 
     if (battstat->last_charging &&
-        battstat->last_acline_status &&
-        battstat->last_acline_status!=1000 &&
+        battstat->last_acline_status == POWER_STATUS_ON &&
         !info.charging &&
         info.on_ac_power &&
         info.present &&
@@ -726,10 +725,10 @@ check_for_updates (gpointer data)
         battstat->refresh_label = FALSE;
     }
 
-    battstat->last_charging = (info.charging != FALSE);
+    battstat->last_charging = info.charging;
     battstat->last_batt_life = info.percent;
     battstat->last_minutes = info.minutes;
-    battstat->last_acline_status = (info.on_ac_power != FALSE);
+    battstat->last_acline_status = info.on_ac_power;
     battstat->last_present = info.present;
 
     return TRUE;
@@ -1143,8 +1142,8 @@ battstat_applet_fill (MatePanelApplet *applet)
     battstat->applet = GTK_WIDGET (applet);
     battstat->refresh_label = TRUE;
     battstat->last_batt_life = 1000;
-    battstat->last_acline_status = 1000;
-    battstat->last_charging = 1000;
+    battstat->last_acline_status = POWER_STATUS_UNKNOWN;
+    battstat->last_charging = POWER_STATUS_UNKNOWN;
     battstat->orienttype = mate_panel_applet_get_orient (applet);
     battstat->battery_low_dialog = NULL;
     battstat->battery_low_label = NULL;

--- a/battstat/power-management.c
+++ b/battstat/power-management.c
@@ -62,9 +62,9 @@
                            "ACPI subsystem is properly loaded.")
 
 static const char *apm_readinfo (BatteryStatus *status);
-static int pm_initialised;
+static gboolean pm_initialised = FALSE;
 #ifdef HAVE_UPOWER
-static int using_upower;
+static gboolean using_upower = FALSE;
 #endif
 
 /*
@@ -263,7 +263,7 @@ apm_readinfo (BatteryStatus *status)
   fd = open(APMDEVICE, O_RDONLY);
   if (fd == -1)
   {
-    pm_initialised = 0;
+    pm_initialised = FALSE;
     return ERR_OPEN_APMDEV;
   }
   if (ioctl (fd, APM_IOC_GETPOWER, &apminfo) == -1)
@@ -442,7 +442,7 @@ power_management_initialise (void (*callback) (void))
 
   if (err == NULL) /* UPOWER is up */
   {
-    pm_initialised = 1;
+    pm_initialised = TRUE;
     using_upower = TRUE;
     return NULL;
   }
@@ -483,7 +483,7 @@ power_management_initialise (void (*callback) (void))
   else
     using_acpi = FALSE;
 #endif
-  pm_initialised = 1;
+  pm_initialised = TRUE;
 
   return NULL;
 }
@@ -500,7 +500,7 @@ power_management_cleanup (void)
   if (using_upower)
   {
     battstat_upower_cleanup ();
-    pm_initialised = 1;
+    pm_initialised = TRUE;
     return;
   }
 #endif
@@ -519,16 +519,16 @@ power_management_cleanup (void)
   }
 #endif
 
-  pm_initialised = 0;
+  pm_initialised = FALSE;
 }
 
-int
+gboolean
 power_management_using_upower (void)
 {
 #ifdef HAVE_UPOWER
  return using_upower;
 #else
- return 0;
+ return FALSE;
 #endif
 }
 


### PR DESCRIPTION
```
CFLAGS="-g -O0 -Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-compile-warnings=maximum && make &> make.log
```
```
battstat_applet.c:729:36: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
    battstat->last_charging = info.charging;
                            ~ ~~~~~^~~~~~~~
--
battstat_applet.c:732:41: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
    battstat->last_acline_status = info.on_ac_power;
                                 ~ ~~~~~^~~~~~~~~~~
```