### PR TITLE
geyes: consider the offset widget <-> window

### DIFF
--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -132,7 +132,7 @@ timer_cb (EyesApplet *eyes_applet)
 {
     GdkDisplay *display;
     GdkSeat *seat;
-    gint x, y;
+    gint x, y, dx, dy;
     gint pupil_x, pupil_y;
     gsize i;
 
@@ -144,6 +144,11 @@ timer_cb (EyesApplet *eyes_applet)
             gdk_window_get_device_position (gtk_widget_get_window (eyes_applet->eyes[i]),
                                             gdk_seat_get_pointer (seat),
                                             &x, &y, NULL);
+            gtk_widget_translate_coordinates (eyes_applet->eyes[i],
+                                              gtk_widget_get_toplevel(eyes_applet->eyes[i]),
+                                              0, 0, &dx, &dy);
+            x -= dx;
+            y -= dy;
 
             if ((x != eyes_applet->pointer_last_x[i]) ||
                 (y != eyes_applet->pointer_last_y[i])) {


### PR DESCRIPTION
Problem: when the mouse pointer is between two eyes, the left one is correct oriented; however the right one is wrongly oriented 

![image](https://user-images.githubusercontent.com/4663983/147945706-c5838179-c934-458b-a7cf-d02f1fda82cb.png)

I discovered that this is due to the fact that it is not computed the offset between the single eye widget and their parent window.

Correct views:
![image](https://user-images.githubusercontent.com/4663983/147945548-547a1139-ebed-4d6b-801b-2bbe4d29c066.png)
![image](https://user-images.githubusercontent.com/4663983/147946045-99323227-b1ba-450e-aa4c-d0fea9468a89.png)
![image](https://user-images.githubusercontent.com/4663983/147946144-b7f8a29c-e230-41d0-acd8-3a16bb96c3bf.png)
![image](https://user-images.githubusercontent.com/4663983/147946269-ee526e1c-0bc3-4954-b80c-6d1054ceb70f.png)








To compute the correct pupil position, we should consider the offset
between the eye widget and their parent window.

Signed-off-by: Goffredo Baroncelli <kreijack@inwind.it>