### PR TITLE
charpick: fix memory leak

### DIFF
--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -447,7 +447,7 @@ build_table (charpick_data *p_curr_data)
                           p_curr_data->applet);
     }
 
-    charlist = g_strdup (p_curr_data->charlist);
+    charlist = p_curr_data->charlist;
     for (i = 0; i < len; i++) {
         gchar label[7];
         GtkRequisition req;


### PR DESCRIPTION
```
Direct leak of 22 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d9c24d93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f4d9a9f94df in g_malloc ../glib/gmem.c:106
    #2 0x7f4d9a9f9822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f4d9aa1be35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x405e63 in build_table /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:450
    #5 0x407b7c in charpicker_applet_fill /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:797
    #6 0x407ef8 in charpicker_applet_factory /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:870
    #7 0x7f4d9c184673 in mate_panel_applet_marshal_BOOLEAN__STRING /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet-marshal.c:122
    #8 0x7f4d9ab08ea5 in g_closure_invoke ../gobject/gclosure.c:830
    #9 0x7f4d9c18cc00 in mate_panel_applet_setup /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:1814
    #10 0x7f4d9ab0cc87 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #11 0x7f4d9ab092e1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #12 0x7f4d9ab2a822 in g_signal_emit_valist ../gobject/gsignal.c:3407
    #13 0x7f4d9ab2bfc1 in g_signal_emit_by_name ../gobject/gsignal.c:3596
    #14 0x7f4d9b77dd72 in gtk_plug_filter_func ../gtk/gtkplug.c:969
    #15 0x7f4d9b128472 in gdk_event_apply_filters ../gdk/x11/gdkeventsource.c:79
    #16 0x7f4d9b127e24 in gdk_event_source_translate_event ../gdk/x11/gdkeventsource.c:205
    #17 0x7f4d9b127cd4 in _gdk_x11_display_queue_events ../gdk/x11/gdkeventsource.c:341
    #18 0x7f4d9b0a17d9 in gdk_display_get_event ../gdk/gdkdisplay.c:442
    #19 0x7f4d9b12882d in gdk_event_source_dispatch ../gdk/x11/gdkeventsource.c:363
    #20 0x7f4d9a9f0116 in g_main_dispatch ../glib/gmain.c:3413
    #21 0x7f4d9a9eff5f in g_main_context_dispatch ../glib/gmain.c:4131
    #22 0x7f4d9a9f0481 in g_main_context_iterate ../glib/gmain.c:4207
    #23 0x7f4d9a9f09a2 in g_main_loop_run ../glib/gmain.c:4405
    #24 0x7f4d9b453935 in gtk_main ../gtk/gtkmain.c:1329
    #25 0x7f4d9c18f0da in _mate_panel_applet_factory_main_internal /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2442
    #26 0x7f4d9c18f12f in mate_panel_applet_factory_main /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2470
    #27 0x408142 in main /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:875
    #28 0x7f4d9a744b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 22 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d9c24d93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f4d9a9f94df in g_malloc ../glib/gmem.c:106
    #2 0x7f4d9a9f9822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f4d9aa1be35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x405e63 in build_table /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:450
    #5 0x406af1 in rebuild_cb /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:557
    #6 0x7f4d9a9eaf0e in g_idle_dispatch ../glib/gmain.c:5929
    #7 0x7f4d9a9f0116 in g_main_dispatch ../glib/gmain.c:3413
    #8 0x7f4d9a9eff5f in g_main_context_dispatch ../glib/gmain.c:4131
    #9 0x7f4d9a9f0481 in g_main_context_iterate ../glib/gmain.c:4207
    #10 0x7f4d9a9f09a2 in g_main_loop_run ../glib/gmain.c:4405
    #11 0x7f4d9b453935 in gtk_main ../gtk/gtkmain.c:1329
    #12 0x7f4d9c18f0da in _mate_panel_applet_factory_main_internal /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2442
    #13 0x7f4d9c18f12f in mate_panel_applet_factory_main /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2470
    #14 0x408142 in main /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:875
    #15 0x7f4d9a744b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 22 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d9c24d93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f4d9a9f94df in g_malloc ../glib/gmem.c:106
    #2 0x7f4d9a9f9822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f4d9aa1be35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x405e63 in build_table /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:450
    #5 0x405698 in populate_menu /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:320
    #6 0x407eb5 in charpicker_applet_fill /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:857
    #7 0x407ef8 in charpicker_applet_factory /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:870
    #8 0x7f4d9c184673 in mate_panel_applet_marshal_BOOLEAN__STRING /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet-marshal.c:122
    #9 0x7f4d9ab08ea5 in g_closure_invoke ../gobject/gclosure.c:830
    #10 0x7f4d9c18cc00 in mate_panel_applet_setup /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:1814
    #11 0x7f4d9ab0cc87 in g_cclosure_marshal_VOID__VOIDv ../gobject/gmarshal.c:165
    #12 0x7f4d9ab092e1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #13 0x7f4d9ab2a822 in g_signal_emit_valist ../gobject/gsignal.c:3407
    #14 0x7f4d9ab2bfc1 in g_signal_emit_by_name ../gobject/gsignal.c:3596
    #15 0x7f4d9b77dd72 in gtk_plug_filter_func ../gtk/gtkplug.c:969
    #16 0x7f4d9b128472 in gdk_event_apply_filters ../gdk/x11/gdkeventsource.c:79
    #17 0x7f4d9b127e24 in gdk_event_source_translate_event ../gdk/x11/gdkeventsource.c:205
    #18 0x7f4d9b127cd4 in _gdk_x11_display_queue_events ../gdk/x11/gdkeventsource.c:341
    #19 0x7f4d9b0a17d9 in gdk_display_get_event ../gdk/gdkdisplay.c:442
    #20 0x7f4d9b12882d in gdk_event_source_dispatch ../gdk/x11/gdkeventsource.c:363
    #21 0x7f4d9a9f0116 in g_main_dispatch ../glib/gmain.c:3413
    #22 0x7f4d9a9eff5f in g_main_context_dispatch ../glib/gmain.c:4131
    #23 0x7f4d9a9f0481 in g_main_context_iterate ../glib/gmain.c:4207
    #24 0x7f4d9a9f09a2 in g_main_loop_run ../glib/gmain.c:4405
    #25 0x7f4d9b453935 in gtk_main ../gtk/gtkmain.c:1329
    #26 0x7f4d9c18f0da in _mate_panel_applet_factory_main_internal /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2442
    #27 0x7f4d9c18f12f in mate_panel_applet_factory_main /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2470
    #28 0x408142 in main /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:875
    #29 0x7f4d9a744b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 17 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d9c24d93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f4d9a9f94df in g_malloc ../glib/gmem.c:106
    #2 0x7f4d9a9f9822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f4d9aa1be35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x405e63 in build_table /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:450
    #5 0x40534b in menuitem_activated /home/robert/builddir.gcc/mate-applets/charpick/charpick.c:285
    #6 0x7f4d9ab0cbcf in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #7 0x7f4d9ab08ea5 in g_closure_invoke ../gobject/gclosure.c:830
    #8 0x7f4d9ab29c42 in signal_emit_unlocked_R ../gobject/gsignal.c:3744
    #9 0x7f4d9ab2b59a in g_signal_emit_valist ../gobject/gsignal.c:3497
    #10 0x7f4d9ab2bd8e in g_signal_emit ../gobject/gsignal.c:3554
    #11 0x7f4d9b65d9b4 in gtk_widget_activate ../gtk/gtkwidget.c:7845
    #12 0x7f4d9b475c7f in gtk_menu_shell_activate_item ../gtk/gtkmenushell.c:1375
    #13 0x7f4d9b4782e1 in gtk_menu_shell_button_release ../gtk/gtkmenushell.c:791
    #14 0x7f4d9b46158d in gtk_menu_button_release ../gtk/gtkmenu.c:3991
    #15 0x7f4d9b233a4a in _gtk_marshal_BOOLEAN__BOXEDv gtk/gtkmarshalers.c:130
    #16 0x7f4d9ab09de5 in g_type_class_meta_marshalv ../gobject/gclosure.c:1058
    #17 0x7f4d9ab092e1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #18 0x7f4d9ab2a822 in g_signal_emit_valist ../gobject/gsignal.c:3407
    #19 0x7f4d9ab2bd8e in g_signal_emit ../gobject/gsignal.c:3554
    #20 0x7f4d9b65cd37 in gtk_widget_event_internal ../gtk/gtkwidget.c:7812
    #21 0x7f4d9b65ca23 in gtk_widget_event ../gtk/gtkwidget.c:7382
    #22 0x7f4d9b4563a9 in propagate_event_up ../gtk/gtkmain.c:2588
    #23 0x7f4d9b45545f in propagate_event ../gtk/gtkmain.c:2691
    #24 0x7f4d9b45498f in gtk_propagate_event ../gtk/gtkmain.c:2725
    #25 0x7f4d9b454245 in gtk_main_do_event ../gtk/gtkmain.c:1921
    #26 0x7f4d9b0a96b4 in _gdk_event_emit ../gdk/gdkevents.c:73
    #27 0x7f4d9b128845 in gdk_event_source_dispatch ../gdk/x11/gdkeventsource.c:367
    #28 0x7f4d9a9f0116 in g_main_dispatch ../glib/gmain.c:3413
    #29 0x7f4d9a9eff5f in g_main_context_dispatch ../glib/gmain.c:4131
```