### PR TITLE
command: fix memory leak

### DIFF
--- a/command/src/command.c
+++ b/command/src/command.c
@@ -225,12 +225,16 @@ settings_command_changed (GSettings *settings, gchar *key, CommandApplet *comman
 
     cmdline = g_settings_get_string (command_applet->settings, COMMAND_KEY);
     if (strlen (cmdline) == 0 || g_strcmp0(command_applet->cmdline, cmdline) == 0)
+    {
+        g_free (cmdline);
         return;
+    }
 
     if (!g_shell_parse_argv (cmdline, NULL, &argv, &error))
     {
         gtk_label_set_text (command_applet->label, ERROR_OUTPUT);
         g_clear_error (&error);
+        g_free (cmdline);
         return;
     }
     g_strfreev(argv);


### PR DESCRIPTION
```
Direct leak of 9 byte(s) in 1 object(s) allocated from:
    #0 0x7fa3b813b93f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7fa3b6e0d4df in g_malloc ../glib/gmem.c:106
    #2 0x7fa3b6e0d822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7fa3b6e2fe35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x7fa3b6e5e6b4 in g_variant_dup_string ../glib/gvariant.c:1543
    #5 0x7fa3b70cd86d in g_settings_get_string ../gio/gsettings.c:1807
    #6 0x404414 in settings_command_changed /home/robert/builddir.gcc/mate-applets/command/src/command.c:226
    #7 0x7fa3b6f228ac in g_cclosure_marshal_VOID__STRINGv ../gobject/gmarshal.c:1462
    #8 0x7fa3b6f1d2e1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #9 0x7fa3b6f3e822 in g_signal_emit_valist ../gobject/gsignal.c:3407
    #10 0x7fa3b6f3fd8e in g_signal_emit ../gobject/gsignal.c:3554
    #11 0x7fa3b70d064b in g_settings_real_change_event ../gio/gsettings.c:390
    #12 0x7fa3b701af20 in _g_cclosure_marshal_BOOLEAN__POINTER_INTv ../gio/gmarshal-internal.c:426
    #13 0x7fa3b6f1dde5 in g_type_class_meta_marshalv ../gobject/gclosure.c:1058
    #14 0x7fa3b6f1d2e1 in _g_closure_invoke_va ../gobject/gclosure.c:893
    #15 0x7fa3b6f3e822 in g_signal_emit_valist ../gobject/gsignal.c:3407
    #16 0x7fa3b6f3fd8e in g_signal_emit ../gobject/gsignal.c:3554
    #17 0x7fa3b70d0e71 in settings_backend_path_changed ../gio/gsettings.c:465
    #18 0x7fa3b70c5344 in g_settings_backend_invoke_closure ../gio/gsettingsbackend.c:273
    #19 0x7fa3b6dfef0e in g_idle_dispatch ../glib/gmain.c:5929
    #20 0x7fa3b6e04116 in g_main_dispatch ../glib/gmain.c:3413
    #21 0x7fa3b6e03f5f in g_main_context_dispatch ../glib/gmain.c:4131
    #22 0x7fa3b6e04481 in g_main_context_iterate ../glib/gmain.c:4207
    #23 0x7fa3b6e049a2 in g_main_loop_run ../glib/gmain.c:4405
    #24 0x7fa3b7867935 in gtk_main ../gtk/gtkmain.c:1329
    #25 0x7fa3b807d0da in _mate_panel_applet_factory_main_internal /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2442
    #26 0x7fa3b807d12f in mate_panel_applet_factory_main /home/robert/builddir.gcc/mate-panel/libmate-panel-applet/mate-panel-applet.c:2470
    #27 0x405f44 in main /home/robert/builddir.gcc/mate-applets/command/src/command.c:501
    #28 0x7fa3b6befb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
```