### PR TITLE
Add click-hide key to the stickynotes GSettings

### DIFF
--- a/stickynotes/org.mate.stickynotes.gschema.xml.in
+++ b/stickynotes/org.mate.stickynotes.gschema.xml.in
@@ -65,5 +65,10 @@
       <summary>Whether to ask for confirmation when deleting a note</summary>
       <description>Empty notes are always deleted without confirmation.</description>
     </key>
+    <key name="click-hide" type="b">
+      <default>true</default>
+      <summary>Whether to hide all notes when click the icon</summary>
+      <description>If this option is disabled, the note is not hidden when the icon is clicked.</description>
+    </key>
   </schema>
 </schemalist>

--- a/stickynotes/stickynotes_applet_callbacks.c
+++ b/stickynotes/stickynotes_applet_callbacks.c
@@ -67,6 +67,10 @@ stickynote_show_notes (gboolean visible)
     GList *l;
 
     if (stickynotes->visible == visible) return;
+
+    if (g_settings_get_boolean (stickynotes->settings, "click-hide") && !visible)
+        return;
+
     stickynotes->visible = visible;
 
     for (l = stickynotes->notes; l; l = l->next) {


### PR DESCRIPTION
Add a new key value "click-hide",When this key is disabled, click the note icon on the panel, and the note will not be hidden
Fix #627 
## test 
1. make PR and install 
2. replace note from panel
3. run ```gsettings set org.mate.stickynotes click-hide false```
4. clicked note icon