### PR TITLE
command: fix -Wincompatible-pointer-types warning

### DIFF
--- a/command/src/command.c
+++ b/command/src/command.c
@@ -469,7 +469,7 @@ command_applet_fill (MatePanelApplet* applet)
                      "visible",
                      G_SETTINGS_BIND_DEFAULT);
 
-    atk_widget = gtk_widget_get_accessible (command_applet->applet);
+    atk_widget = gtk_widget_get_accessible (GTK_WIDGET (command_applet->applet));
     if (GTK_IS_ACCESSIBLE (atk_widget)) {
         atk_object_set_name (atk_widget,
                              _("Command applet"));


### PR DESCRIPTION
```
command.c:472:45: warning: incompatible pointer types passing 'MatePanelApplet *' (aka 'struct _MatePanelApplet *') to parameter of type 'GtkWidget *' (aka 'struct _GtkWidget *') [-Wincompatible-pointer-types]
    atk_widget = gtk_widget_get_accessible (command_applet->applet);
                                            ^~~~~~~~~~~~~~~~~~~~~~
/usr/include/gtk-3.0/gtk/gtkwidget.h:1067:79: note: passing argument to parameter 'widget' here
AtkObject*       gtk_widget_get_accessible               (GtkWidget          *widget);
                                                                              ^
```