### PR TITLE
stickynotes: bump gtksourceview 4

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -10,7 +10,7 @@ requires:
     - gcc
     - git
     - gucharmap
-    - gtksourceview3
+    - gtksourceview4
     - itstool
     - libgtop
     - libnotify
@@ -39,7 +39,7 @@ requires:
     - libdbus-glib-1-dev
     - libglib2.0-dev
     - libgtk-3-dev
-    - libgtksourceview-3.0-dev
+    - libgtksourceview-4-dev
     - libgtop2-dev
     - libgucharmap-2-90-dev
     - libiw-dev
@@ -67,7 +67,7 @@ requires:
     - cppcheck-htmlreport
     - gcc
     - git
-    - gtksourceview3-devel
+    - gtksourceview4-devel
     - gucharmap-devel
     - kernel-tools-libs-devel
     - libgtop2-devel
@@ -101,7 +101,7 @@ requires:
     - libdbus-glib-1-dev
     - libglib2.0-dev
     - libgtk-3-dev
-    - libgtksourceview-3.0-dev
+    - libgtksourceview-4-dev
     - libgtop2-dev
     - libgucharmap-2-90-dev
     - libiw-dev

--- a/configure.ac
+++ b/configure.ac
@@ -296,7 +296,7 @@ AC_ARG_ENABLE([stickynotes],
     enable_stickynotes=$enableval,
     enable_stickynotes=yes)
 if test "x$enable_stickynotes" = "xyes"; then
-    PKG_CHECK_MODULES(STICKYNOTES, gtksourceview-3.0,
+    PKG_CHECK_MODULES(STICKYNOTES, gtksourceview-4,
                       have_gtksourceview=yes, have_gtksourceview=no)
 
     if test "x$enable_stickynotes" = "xyes" -a "x$have_gtksourceview" = "xno"; then

--- a/stickynotes/sticky-notes-note.ui
+++ b/stickynotes/sticky-notes-note.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
-  <requires lib="gtksourceview" version="3.0"/>
+  <requires lib="gtksourceview" version="4.0"/>
   <object class="GtkSourceBuffer" id="body_buffer">
     <property name="max_undo_levels">-1</property>
   </object>

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -27,8 +27,6 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include <gtksourceview/gtksource.h>
-
 #include "stickynotes.h"
 #include "stickynotes_callbacks.h"
 #include "util.h"


### PR DESCRIPTION
GtkSourceBuffer provides the ability to undo or redo the change to the note text-body.  [pluma](https://github.com/mate-desktop/pluma/commit/69870af1aed34b32a48ff75554b4438e222cc526) uses gtksourceview 4, so we don't need to depend on two versions.

fix #634