### PR TITLE
build: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name

### DIFF
--- a/accessx-status/src/Makefile.am
+++ b/accessx-status/src/Makefile.am
@@ -20,10 +20,10 @@ accessx_status_applet_LDADD = \
 	$(GIO_LIBS) \
 	$(X_LIBS)
 
-accessx-status-resources.c: $(srcdir)/../data/accessx-status-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/accessx-status-resources.gresource.xml)
+accessx-status-resources.c: $(srcdir)/../data/accessx-status-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/accessx-status-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name accessx $<
 
-accessx-status-resources.h: $(srcdir)/../data/accessx-status-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/accessx-status-resources.gresource.xml)
+accessx-status-resources.h: $(srcdir)/../data/accessx-status-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/accessx-status-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name accessx $<
 
 CLEANFILES = \

--- a/battstat/Makefile.am
+++ b/battstat/Makefile.am
@@ -59,10 +59,10 @@ battstat_applet_LDADD =		\
 	-lm			\
 	$(NULL)
 
-battstat-resources.c: battstat-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml)
+battstat-resources.c: battstat-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name battstat $<
 
-battstat-resources.h: battstat-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml)
+battstat-resources.h: battstat-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name battstat $<
 
 batstat_gschema_in_files = org.mate.panel.applet.battstat.gschema.xml.in

--- a/charpick/Makefile.am
+++ b/charpick/Makefile.am
@@ -26,10 +26,10 @@ mate_charpick_applet_LDADD =	\
 	$(GUCHARMAP_LIBS)	\
 	$(NULL)
 
-charpick-resources.c: charpick-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/charpick-resources.gresource.xml)
+charpick-resources.c: charpick-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/charpick-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name charpick $<
 
-charpick-resources.h: charpick-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/charpick-resources.gresource.xml)
+charpick-resources.h: charpick-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/charpick-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name charpick $<
 
 appletdir       = $(datadir)/mate-panel/applets

--- a/command/src/Makefile.am
+++ b/command/src/Makefile.am
@@ -31,10 +31,10 @@ command_applet_CFLAGS =		\
 	$(WARN_CFLAGS)		\
 	$(NULL)
 
-command-resources.c: $(srcdir)/../data/command-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml)
+command-resources.c: $(srcdir)/../data/command-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name command $<
 
-command-resources.h: $(srcdir)/../data/command-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml)
+command-resources.h: $(srcdir)/../data/command-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name command $<
 
 CLEANFILES =			\

--- a/cpufreq/src/Makefile.am
+++ b/cpufreq/src/Makefile.am
@@ -44,10 +44,10 @@ mate_cpufreq_applet_LDADD =		\
 	$(MATE_APPLETS4_LIBS)   	\
 	$(LIBCPUFREQ_LIBS)
 
-cpufreq-resources.c: $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq --generate-dependencies $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml)
+cpufreq-resources.c: $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq --generate-dependencies $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq --generate --c-name cpufreq $<
 
-cpufreq-resources.h: $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq --generate-dependencies $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml)
+cpufreq-resources.h: $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq --generate-dependencies $(top_srcdir)/cpufreq/cpufreq-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq --generate --c-name cpufreq $<
 
 CLEANFILES = \

--- a/drivemount/src/Makefile.am
+++ b/drivemount/src/Makefile.am
@@ -30,10 +30,10 @@ mate_drivemount_applet_SOURCES =	\
 mate_drivemount_applet_LDADD =		\
 	$(MATE_APPLETS4_LIBS)
 
-drivemount-resources.c: ../data/drivemount-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml)
+drivemount-resources.c: ../data/drivemount-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name drivemount $<
 
-drivemount-resources.h: ../data/drivemount-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml)
+drivemount-resources.h: ../data/drivemount-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name drivemount $<
 
 CLEANFILES =				\

--- a/geyes/src/Makefile.am
+++ b/geyes/src/Makefile.am
@@ -23,10 +23,10 @@ mate_geyes_applet_LDADD =	\
 	$(MATE_APPLETS4_LIBS)	\
 	-lm
 
-geyes-resources.c: $(srcdir)/../data/geyes-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/geyes-resources.gresource.xml)
+geyes-resources.c: $(srcdir)/../data/geyes-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/geyes-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name eyes $<
 
-geyes-resources.h: $(srcdir)/../data/geyes-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/geyes-resources.gresource.xml)
+geyes-resources.h: $(srcdir)/../data/geyes-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/geyes-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name eyes $<
 
 CLEANFILES =			\

--- a/mateweather/src/Makefile.am
+++ b/mateweather/src/Makefile.am
@@ -25,11 +25,12 @@ mateweather_applet_LDADD = 	\
 	$(MATE_LIBS2_LIBS)	\
 	$(LIBMATEWEATHER_LIBS)
 
-mateweather-resources.c: ../data/mateweather-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml)
+mateweather-resources.c: ../data/mateweather-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name mateweather $<
 
-mateweather-resources.h: ../data/mateweather-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml)
+mateweather-resources.h: ../data/mateweather-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name mateweather $<
+
 
 CLEANFILES =			\
 	$(BUILT_SOURCES)

--- a/multiload/src/Makefile.am
+++ b/multiload/src/Makefile.am
@@ -30,10 +30,10 @@ mate_multiload_applet_LDADD = \
 	$(GIO_LIBS) \
 	-lm
 
-multiload-resources.c: $(srcdir)/../data/multiload-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/multiload-resources.gresource.xml)
+multiload-resources.c: $(srcdir)/../data/multiload-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/multiload-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name multiload $<
 
-multiload-resources.h: $(srcdir)/../data/multiload-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/multiload-resources.gresource.xml)
+multiload-resources.h: $(srcdir)/../data/multiload-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/multiload-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name multiload $<
 
 CLEANFILES = \

--- a/netspeed/src/Makefile.am
+++ b/netspeed/src/Makefile.am
@@ -44,10 +44,10 @@ if HAVE_NL
 mate_netspeed_applet_LDADD += $(NL_LIBS)
 endif
 
-netspeed-resources.c: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml)
+netspeed-resources.c: $(srcdir)/../data/netspeed-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name netspeed $<
 
-netspeed-resources.h: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml)
+netspeed-resources.h: $(srcdir)/../data/netspeed-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name netspeed $<
 
 CLEANFILES =			\

--- a/stickynotes/Makefile.am
+++ b/stickynotes/Makefile.am
@@ -45,10 +45,10 @@ stickynotes_gschema_in_files = org.mate.stickynotes.gschema.xml.in
 gsettings_SCHEMAS = $(stickynotes_gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
-sticky-notes-resources.c: sticky-notes-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/sticky-notes-resources.gresource.xml)
+sticky-notes-resources.c: sticky-notes-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/sticky-notes-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name sticky_notes $<
 
-sticky-notes-resources.h: sticky-notes-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/sticky-notes-resources.gresource.xml)
+sticky-notes-resources.h: sticky-notes-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/sticky-notes-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name sticky_notes $<
 
 appletdir   = $(datadir)/mate-panel/applets

--- a/timerapplet/src/Makefile.am
+++ b/timerapplet/src/Makefile.am
@@ -22,10 +22,10 @@ timer_applet_LDADD =		\
 
 timer_applet_CFLAGS = $(WARN_CFLAGS)
 
-timerapplet-resources.c: $(srcdir)/../data/timerapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml)
+timerapplet-resources.c: $(srcdir)/../data/timerapplet-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
 
-timerapplet-resources.h: $(srcdir)/../data/timerapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml)
+timerapplet-resources.h: $(srcdir)/../data/timerapplet-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
 
 CLEANFILES =			\

--- a/trashapplet/src/Makefile.am
+++ b/trashapplet/src/Makefile.am
@@ -23,10 +23,10 @@ trashapplet_LDADD = 		\
 	$(GIO_LIBS) \
 	-lX11
 
-trashapplet-resources.c: ../trashapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../ --generate-dependencies $(srcdir)/../trashapplet-resources.gresource.xml)
+trashapplet-resources.c: ../trashapplet-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../ --generate-dependencies $(srcdir)/../trashapplet-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../ --generate --c-name trashapplet $<
 
-trashapplet-resources.h: ../trashapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../ --generate-dependencies $(srcdir)/../trashapplet-resources.gresource.xml)
+trashapplet-resources.h: ../trashapplet-resources.gresource.xml `$(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../ --generate-dependencies $(srcdir)/../trashapplet-resources.gresource.xml`
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../ --generate --c-name trashapplet $<
 
 CLEANFILES = \


### PR DESCRIPTION
```
accessx-status/src/Makefile.am:23: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
accessx-status/src/Makefile.am:26: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
battstat/Makefile.am:62: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
battstat/Makefile.am:65: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
charpick/Makefile.am:29: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
charpick/Makefile.am:32: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
command/src/Makefile.am:34: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
command/src/Makefile.am:37: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
cpufreq/src/Makefile.am:47: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
cpufreq/src/Makefile.am:50: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
drivemount/src/Makefile.am:33: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
drivemount/src/Makefile.am:36: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
geyes/src/Makefile.am:26: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
geyes/src/Makefile.am:29: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
mateweather/src/Makefile.am:28: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
mateweather/src/Makefile.am:31: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
multiload/src/Makefile.am:33: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
multiload/src/Makefile.am:36: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
netspeed/src/Makefile.am:47: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
netspeed/src/Makefile.am:50: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
stickynotes/Makefile.am:48: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
stickynotes/Makefile.am:51: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
timerapplet/src/Makefile.am:25: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
timerapplet/src/Makefile.am:28: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
trashapplet/src/Makefile.am:26: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
trashapplet/src/Makefile.am:29: warning: shell $(GLIB_COMPILE_RESOURCES: non-POSIX variable name
```