### PR TITLE
Fixed-size notes support

### DIFF
--- a/stickynotes/org.mate.stickynotes.gschema.xml.in
+++ b/stickynotes/org.mate.stickynotes.gschema.xml.in
@@ -70,5 +70,10 @@
       <summary>Whether to hide all notes when click the icon</summary>
       <description>If this option is disabled, the note is not hidden when the icon is clicked.</description>
     </key>
+    <key name="fixed-size" type="b">
+      <default>false</default>
+      <summary>Whether to prevent note resizing on all notes</summary>
+      <description>If this option is enabled, resizing is restricted on all notes.</description>
+    </key>
   </schema>
 </schemalist>

--- a/stickynotes/sticky-notes-preferences.ui
+++ b/stickynotes/sticky-notes-preferences.ui
@@ -390,6 +390,23 @@
                         <property name="width">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="fixed_size_check">
+                        <property name="label" translatable="yes">Force fixed size notes</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Choose whether to restrict notes resizing</property>
+                        <property name="halign">start</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -86,7 +86,7 @@ static void
 buffer_changed (GtkTextBuffer *buffer,
                 StickyNote    *note)
 {
-    if ( (note->h + note->y) > stickynotes->max_height )
+    if ( (note->h + note->y) > stickynotes->max_height && (!note->force_fixed_size) )
         gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (note->w_scroller),
                                         GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 
@@ -201,6 +201,7 @@ stickynote_new_aux (GdkScreen *screen,
     note->font_color = NULL;
     note->font = NULL;
     note->locked = FALSE;
+    note->force_fixed_size = FALSE;
     note->x = x;
     note->y = y;
     note->w = w;
@@ -255,6 +256,8 @@ stickynote_new_aux (GdkScreen *screen,
     stickynote_set_color (note, NULL, NULL, TRUE);
     stickynote_set_font (note, NULL, TRUE);
     stickynote_set_locked (note, FALSE);
+
+    stickynote_set_fixed_size (note, stickynotes->force_fixed_size);
 
     gtk_widget_realize (note->w_window);
 
@@ -760,6 +763,46 @@ stickynote_set_visible (StickyNote *note,
         set_icon_geometry (gtk_widget_get_window (GTK_WIDGET (note->w_window)),
                            x, y, width, height);
         gtk_window_iconify (GTK_WINDOW (note->w_window));
+    }
+}
+
+/* Set forced fixed size */
+void stickynote_set_fixed_size (StickyNote *note,
+                                gboolean    force_fixed_size)
+{
+    note->force_fixed_size = force_fixed_size;
+
+    if (force_fixed_size) {
+        gint w, h;
+        gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (note->w_scroller),
+                                        GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+        gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (note->w_body),
+                                     GTK_WRAP_CHAR);
+        gtk_widget_set_visible (note->w_resize_se, FALSE);
+        gtk_widget_set_visible (note->w_resize_sw, FALSE);
+        if (note->w == 0 && note->h == 0) {
+            w = g_settings_get_int (stickynotes->settings, "default-width");
+            h = g_settings_get_int (stickynotes->settings, "default-height");
+        }
+        else {
+            w = note->w;
+            h = note->h;
+        }
+        gtk_window_set_default_size (GTK_WINDOW (note->w_window), w, h);
+        gtk_window_resize (GTK_WINDOW (note->w_window), w, h);
+        gtk_window_set_resizable (GTK_WINDOW (note->w_window), FALSE);
+    }
+    else {
+        GtkPolicyType vscroll_pol = GTK_POLICY_NEVER;
+        if ((note->h + note->y) > stickynotes->max_height)
+            vscroll_pol = GTK_POLICY_AUTOMATIC;
+        gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (note->w_scroller),
+                                        GTK_POLICY_NEVER, vscroll_pol);
+        gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (note->w_body),
+                                     GTK_WRAP_WORD);
+        gtk_widget_set_visible (note->w_resize_se, TRUE);
+        gtk_widget_set_visible (note->w_resize_sw, TRUE);
+        gtk_window_set_resizable (GTK_WINDOW (note->w_window), TRUE);
     }
 }
 

--- a/stickynotes/stickynotes.h
+++ b/stickynotes/stickynotes.h
@@ -61,6 +61,7 @@ typedef struct
     gchar *font_color;                    /* Font color */
     gchar *font;                          /* Note font */
     gboolean locked;                      /* Note locked state */
+    gboolean force_fixed_size;            /* Note resizing is restricted */
 
     gint x;                               /* Note x-coordinate */
     gint y;                               /* Note y-coordinate */
@@ -89,6 +90,8 @@ void stickynote_set_locked (StickyNote *note,
                             gboolean    locked);
 void stickynote_set_visible (StickyNote *note,
                              gboolean    visible);
+void stickynote_set_fixed_size (StickyNote *note,
+                                gboolean    force_fixed_size);
 
 void stickynote_change_properties (StickyNote *note);
 

--- a/stickynotes/stickynotes_applet.c
+++ b/stickynotes/stickynotes_applet.c
@@ -283,6 +283,9 @@ stickynotes_applet_init_prefs (void)
     stickynotes->w_prefs_desktop =
         GTK_WIDGET (&GTK_CHECK_BUTTON (gtk_builder_get_object (stickynotes->builder,
                                                                "desktop_hide_check"))->toggle_button);
+    stickynotes->w_prefs_fixed_size =
+        GTK_WIDGET (&GTK_CHECK_BUTTON (gtk_builder_get_object (stickynotes->builder,
+                                                               "fixed_size_check"))->toggle_button);
 
     g_signal_connect (stickynotes->w_prefs, "response",
                       G_CALLBACK (preferences_response_cb), NULL);
@@ -307,6 +310,8 @@ stickynotes_applet_init_prefs (void)
     g_signal_connect_swapped (stickynotes->w_prefs_force, "toggled",
                               G_CALLBACK (preferences_save_cb), NULL);
     g_signal_connect_swapped (stickynotes->w_prefs_desktop, "toggled",
+                              G_CALLBACK (preferences_save_cb), NULL);
+    g_signal_connect_swapped (stickynotes->w_prefs_fixed_size, "toggled",
                               G_CALLBACK (preferences_save_cb), NULL);
 
     {
@@ -367,6 +372,8 @@ stickynotes_applet_init_prefs (void)
         gtk_widget_set_sensitive (stickynotes->w_prefs_sticky, FALSE);
     if (!g_settings_is_writable (stickynotes->settings, "force-default"))
         gtk_widget_set_sensitive (stickynotes->w_prefs_force, FALSE);
+    if (!g_settings_is_writable (stickynotes->settings, "fixed-size"))
+        gtk_widget_set_sensitive (stickynotes->w_prefs_fixed_size, FALSE);
 
     stickynotes_applet_update_prefs ();
 }
@@ -489,7 +496,7 @@ void
 stickynotes_applet_update_prefs (void)
 {
     gint width, height;
-    gboolean sys_color, sys_font, sticky, force_default, desktop_hide;
+    gboolean sys_color, sys_font, sticky, force_default, desktop_hide, fixed_size;
     char *font_str;
     char *color_str, *font_color_str;
     GdkRGBA color, font_color;
@@ -511,6 +518,8 @@ stickynotes_applet_update_prefs (void)
                                             "force-default");
     desktop_hide = g_settings_get_boolean (stickynotes->settings,
                                            "desktop-hide");
+    fixed_size = g_settings_get_boolean (stickynotes->settings,
+                                         "fixed-size");
 
     font_str = g_settings_get_string (stickynotes->settings,
                                       "default-font");
@@ -545,6 +554,9 @@ stickynotes_applet_update_prefs (void)
                                   force_default);
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_desktop),
                                   desktop_hide);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_fixed_size),
+                                  fixed_size);
+    stickynotes->force_fixed_size = fixed_size;
 
     gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (stickynotes->w_prefs_color),
                                 &color);

--- a/stickynotes/stickynotes_applet.h
+++ b/stickynotes/stickynotes_applet.h
@@ -50,6 +50,7 @@ typedef struct
     GtkWidget *w_prefs_sticky;
     GtkWidget *w_prefs_force;
     GtkWidget *w_prefs_desktop;
+    GtkWidget *w_prefs_fixed_size;
 
     GList *notes;     /* Linked-List of all the sticky notes */
     GList *applets;   /* Linked-List of all the applets */
@@ -63,6 +64,7 @@ typedef struct
     guint last_timeout_data;
 
     gboolean visible;    /* Toggle show/hide notes */
+    gboolean force_fixed_size;  /* Force fixed size notes */
 } StickyNotes;
 
 /* Sticky Notes Applet */

--- a/stickynotes/stickynotes_applet_callbacks.c
+++ b/stickynotes/stickynotes_applet_callbacks.c
@@ -478,6 +478,7 @@ preferences_save_cb (gpointer data)
     gboolean sticky;
     gboolean force_default;
     gboolean desktop_hide;
+    gboolean fixed_size;
     gdouble  adjustment_value;
 
     adjustment_value = gtk_adjustment_get_value (stickynotes->w_prefs_width);
@@ -491,6 +492,7 @@ preferences_save_cb (gpointer data)
     sticky        = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_sticky));
     force_default = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_force));
     desktop_hide  = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_desktop));
+    fixed_size    = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (stickynotes->w_prefs_fixed_size));
 
     if (g_settings_is_writable (stickynotes->settings,
                                 "default-width"))
@@ -520,6 +522,10 @@ preferences_save_cb (gpointer data)
                                 "desktop-hide"))
         g_settings_set_boolean (stickynotes->settings,
                                 "desktop-hide", desktop_hide);
+    if (g_settings_is_writable (stickynotes->settings,
+                                "fixed-size"))
+        g_settings_set_boolean (stickynotes->settings,
+                                "fixed-size", fixed_size);
 }
 
 /* Preferences Callback : Change color. */
@@ -623,6 +629,14 @@ preferences_apply_cb (GSettings *settings,
             stickynote_set_font (note,
                                  note->font,
                                  FALSE);
+        }
+    }
+
+    else if (!strcmp (key, "fixed-size")) {
+        gboolean fixed = g_settings_get_boolean (settings, "fixed-size");
+        for (l = stickynotes->notes; l; l = l->next) {
+            note = l->data;
+            stickynote_set_fixed_size (note, fixed);
         }
     }
 

--- a/stickynotes/stickynotes_callbacks.c
+++ b/stickynotes/stickynotes_callbacks.c
@@ -45,6 +45,9 @@ gboolean stickynote_resize_cb (GtkWidget      *widget,
                                GdkEventButton *event,
                                StickyNote     *note)
 {
+    if (note->force_fixed_size)
+        return FALSE;
+
     if (event->type == GDK_BUTTON_PRESS && event->button == 1) {
         if (widget == note->w_resize_se)
             gtk_window_begin_resize_drag (GTK_WINDOW (note->w_window),


### PR DESCRIPTION
Hi all,

These changes apply to **stickynotes only.**

This is my first PR on a Mate repo. Please bear with me, since there are a few things that are not straightforward:

1) Multiple changes were done automatically by the build system into .po files.
    I understand these are translation files caused by a change I did in stickynotes/sticky-notes-preferences.ui
2) All changes were verified manually in my host (RHEL 8). I'm not sure if your CI/CD system will kick in during PR.
3) Is there a way to get this branch backported to 1.26?

**What is being enhanced & fixed:**
1) [Enhanced] Support for fixed size notes. That is, a mechanism to disallow notes resizing (on all notes).
2) [Bug fix] On a large note (vertical length > screen height), after restarting the stickynotes applet there are no verifications of the w,h sizes stored in the xml file; as consequence no automatic scrollbar is set, leading to an ugly and difficult to manage note.
  This is fixed now, since during startup a check based on screen size is done (propagated from existed code).

Please look at the following images to get an idea of the code changes:

![Screenshot from 2022-09-04 20-09-07](https://user-images.githubusercontent.com/1594532/188353435-de8f8fe3-6519-4c5a-819d-846e2a86e166.png)

![Screenshot from 2022-09-04 20-09-27](https://user-images.githubusercontent.com/1594532/188353466-b6df36aa-8275-4196-925d-fdbb6a5411f2.png)

I decided to make these changes since the stickynotes applet has been one of my main productivity tools since 2014 (I used to run RHEL 5 at that time).

Please let me know if there is any change needed or edit as you see fit.

Thanks
--
Quintin Maldonado