### PR TITLE
Port all wayland-usable applets to in-process

### DIFF
--- a/accessx-status/data/Makefile.am
+++ b/accessx-status/data/Makefile.am
@@ -1,26 +1,36 @@
 NULL =
 
-appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.AccessxStatusApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.AccessxStatusAppletFactory.service.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-accessx-status-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/accessx-status-applet
+endif !ENABLE_IN_PROCESS
+
+appletdir       = $(datadir)/mate-panel/applets
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.AccessxStatusAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
-org.mate.panel.applet.AccessxStatusAppletFactory.service: $(service_in_files)
+$(service_DATA): $(service_in_files) Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@
+endif !ENABLE_IN_PROCESS
 
 CLEANFILES = \
 	$(applet_DATA) \

--- a/accessx-status/data/org.mate.applets.AccessxStatusApplet.mate-panel-applet.desktop.in.in
+++ b/accessx-status/data/org.mate.applets.AccessxStatusApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=AccessxStatusAppletFactory
-Location=@LIBEXECDIR@/accessx-status-applet
+Location=@APPLET_LOCATION@
+InProcess=@APPLET_IN_PROCESS@
 Name=AccessX Status Applet Factory
 Description=Keyboard Accessibility Status Applet Factory
 
@@ -10,6 +11,7 @@ Description=Shows the status of keyboard accessibility features
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=preferences-desktop-accessibility
 MateComponentId=OAFIID:MATE_AccessxStatusApplet
+Platforms=X11;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=keyboard-accessibility (accessx-status)

--- a/accessx-status/data/org.mate.panel.applet.AccessxStatusAppletFactory.service.in
+++ b/accessx-status/data/org.mate.panel.applet.AccessxStatusAppletFactory.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.mate.panel.applet.AccessxStatusAppletFactory
-Exec=@LIBEXECDIR@/accessx-status-applet
+Exec=@APPLET_LOCATION@

--- a/accessx-status/src/Makefile.am
+++ b/accessx-status/src/Makefile.am
@@ -7,18 +7,30 @@ AM_CPPFLAGS = \
 	-DACCESSX_RESOURCE_PATH=\""/org/mate/mate-applets/accessx-status/"\" \
 	$(NULL)
 
-libexec_PROGRAMS = accessx-status-applet
-
 BUILT_SOURCES = accessx-status-resources.c accessx-status-resources.h
-nodist_accessx_status_applet_SOURCES = $(BUILT_SOURCES)
-accessx_status_applet_SOURCES = \
+APPLET_SOURCES = \
 	applet.c \
 	applet.h
 
-accessx_status_applet_LDADD = \
+APPLET_LIBS = \
 	$(MATE_APPLETS4_LIBS) \
 	$(GIO_LIBS) \
 	$(X_LIBS)
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-accessx-status-applet.la
+nodist_libmate_accessx_status_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_accessx_status_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_accessx_status_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_accessx_status_applet_la_LDFLAGS = -module -avoid-version
+libmate_accessx_status_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = accessx-status-applet
+nodist_accessx_status_applet_SOURCES = $(BUILT_SOURCES)
+accessx_status_applet_SOURCES = $(APPLET_SOURCES)
+accessx_status_applet_CFLAGS = $(AM_CFLAGS)
+accessx_status_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 accessx-status-resources.c: $(srcdir)/../data/accessx-status-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/accessx-status-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name accessx $<

--- a/accessx-status/src/applet.c
+++ b/accessx-status/src/applet.c
@@ -1316,7 +1316,9 @@ create_applet (MatePanelApplet* applet)
     GtkIconTheme *icon_theme;
     gint icon_size, icon_scale;
 
+#ifndef ENABLE_IN_PROCESS
     g_set_application_name (_("AccessX Status"));
+#endif
 
     sapplet->xkb = NULL;
     sapplet->xkb_display = NULL;
@@ -1633,9 +1635,9 @@ accessx_status_applet_fill (MatePanelApplet* applet)
     }
 
     g_object_connect (sapplet->applet,
-                      "destroy", accessx_status_applet_destroy, sapplet,
-                      "change-orient", accessx_status_applet_reorient, sapplet,
-                      "change-size", accessx_status_applet_resize, sapplet,
+                      "signal::destroy", accessx_status_applet_destroy, sapplet,
+                      "signal::change-orient", accessx_status_applet_reorient, sapplet,
+                      "signal::change-size", accessx_status_applet_resize, sapplet,
                       NULL);
 
     g_signal_connect (sapplet->applet, "button-press-event",
@@ -1697,9 +1699,9 @@ accessx_status_applet_factory (MatePanelApplet* applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("AccessxStatusAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "accessx-status",
-                                       accessx_status_applet_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("AccessxStatusAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "accessx-status",
+                      accessx_status_applet_factory,
+                      NULL)
 

--- a/battstat/Makefile.am
+++ b/battstat/Makefile.am
@@ -1,5 +1,7 @@
 NULL =
 
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-battstat-applet.so
+
 ACPIINC= @ACPIINC@
 
 if NEED_LIBAPM
@@ -22,6 +24,9 @@ SUBDIRS = docs sounds $(APMDIR)
 
 DIST_SUBDIRS = docs sounds apmlib
 
+mate_battstat_applet_libdir= $(pkglibdir)
+mate_battstat_applet_lib_LTLIBRARIES=libmate-battstat-applet.la
+
 AM_CPPFLAGS =					\
 	${WARN_CFLAGS}				\
 	$(MATE_APPLETS4_CFLAGS)			\
@@ -33,11 +38,8 @@ AM_CPPFLAGS =					\
 	-DBATTSTAT_RESOURCE_PATH=\""/org/mate/mate-applets/battstat/"\" \
 	$(NULL)
 
-libexec_PROGRAMS = battstat-applet
 
-BUILT_SOURCES = battstat-resources.c battstat-resources.h
-nodist_battstat_applet_SOURCES = $(BUILT_SOURCES)
-battstat_applet_SOURCES =	\
+libmate_battstat_applet_la_SOURCES =	\
 	battstat.h		\
 	battstat_applet.c	\
 	battstat-preferences.c  \
@@ -49,9 +51,11 @@ battstat_applet_SOURCES =	\
 	acpi-freebsd.h		\
 	battstat-upower.c	\
 	battstat-upower.h	\
+	battstat-resources.c \
+	battstat-resources.h  \
 	$(NULL)
 
-battstat_applet_LDADD =		\
+libmate_battstat_applet_la_LIBADD =		\
 	$(MATE_APPLETS4_LIBS)	\
 	$(LIBNOTIFY_LIBS)	\
 	$(APMLIB)		\
@@ -75,26 +79,17 @@ applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-ap
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.BattstatAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.BattstatAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 CLEANFILES =			\
 	$(applet_DATA)		\
 	$(applet_in_files)	\
-	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
 	$(BUILT_SOURCES)	\
 	*.gschema.valid		\
@@ -105,7 +100,6 @@ EXTRA_DIST =					\
 	battstat-preferences.ui			\
 	battstat-resources.gresource.xml	\
 	$(applet_in_files).in			\
-	$(service_in_files)			\
 	$(batstat_gschema_in_files)		\
 	$(NULL)
 

--- a/battstat/Makefile.am
+++ b/battstat/Makefile.am
@@ -1,7 +1,5 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-battstat-applet.so
-
 ACPIINC= @ACPIINC@
 
 if NEED_LIBAPM
@@ -24,8 +22,9 @@ SUBDIRS = docs sounds $(APMDIR)
 
 DIST_SUBDIRS = docs sounds apmlib
 
-mate_battstat_applet_libdir= $(pkglibdir)
-mate_battstat_applet_lib_LTLIBRARIES=libmate-battstat-applet.la
+applet_in_files = org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.BattstatAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.battstat.gschema.xml.in
 
 AM_CPPFLAGS =					\
 	${WARN_CFLAGS}				\
@@ -38,11 +37,14 @@ AM_CPPFLAGS =					\
 	-DBATTSTAT_RESOURCE_PATH=\""/org/mate/mate-applets/battstat/"\" \
 	$(NULL)
 
-
-libmate_battstat_applet_la_SOURCES =	\
+BUILT_SOURCES =			\
+	battstat-resources.c	\
+	battstat-resources.h	\
+	$(NULL)
+APPLET_SOURCES =		\
 	battstat.h		\
 	battstat_applet.c	\
-	battstat-preferences.c  \
+	battstat-preferences.c	\
 	battstat-preferences.h	\
 	power-management.c	\
 	acpi-linux.c		\
@@ -51,11 +53,9 @@ libmate_battstat_applet_la_SOURCES =	\
 	acpi-freebsd.h		\
 	battstat-upower.c	\
 	battstat-upower.h	\
-	battstat-resources.c \
-	battstat-resources.h  \
 	$(NULL)
 
-libmate_battstat_applet_la_LIBADD =		\
+APPLET_LIBS =			\
 	$(MATE_APPLETS4_LIBS)	\
 	$(LIBNOTIFY_LIBS)	\
 	$(APMLIB)		\
@@ -63,23 +63,50 @@ libmate_battstat_applet_la_LIBADD =		\
 	-lm			\
 	$(NULL)
 
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-battstat-applet.so
+
+pkglib_LTLIBRARIES = libmate-battstat-applet.la
+nodist_libmate_battstat_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_battstat_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_battstat_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_battstat_applet_la_LDFLAGS = -module -avoid-version
+libmate_battstat_applet_la_LIBADD = $(APPLET_LIBS)
+
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/battstat-applet
+
+libexec_PROGRAMS = battstat-applet
+nodist_battstat_applet_SOURCES = $(BUILT_SOURCES)
+battstat_applet_SOURCES = $(APPLET_SOURCES)
+battstat_applet_CFLAGS = $(AM_CFLAGS)
+battstat_applet_LDADD = $(APPLET_LIBS)
+
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+	    -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+	    $< > $@
+endif !ENABLE_IN_PROCESS
+
 battstat-resources.c: battstat-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name battstat $<
 
 battstat-resources.h: battstat-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/battstat-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name battstat $<
 
-batstat_gschema_in_files = org.mate.panel.applet.battstat.gschema.xml.in
-gsettings_SCHEMAS = $(batstat_gschema_in_files:.xml.in=.xml)
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
             -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+            -e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
@@ -90,6 +117,7 @@ $(applet_DATA): $(applet_in_files) Makefile
 CLEANFILES =			\
 	$(applet_DATA)		\
 	$(applet_in_files)	\
+	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
 	$(BUILT_SOURCES)	\
 	*.gschema.valid		\
@@ -100,7 +128,8 @@ EXTRA_DIST =					\
 	battstat-preferences.ui			\
 	battstat-resources.gresource.xml	\
 	$(applet_in_files).in			\
-	$(batstat_gschema_in_files)		\
+	$(service_in_files)			\
+	$(gschema_in_files)			\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -1130,6 +1130,10 @@ battstat_applet_fill (MatePanelApplet *applet)
 
     if (DEBUG) g_print ("main ()\n");
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Battery Charge Monitor"));
+#endif
+
     gtk_window_set_default_icon_name ("battery");
 
     mate_panel_applet_set_flags (applet,
@@ -1208,9 +1212,8 @@ battstat_applet_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("BattstatAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "battstat",
-                                       battstat_applet_factory,
-                                       NULL)
-
+PANEL_APPLET_FACTORY ("BattstatAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "battstat",
+                      battstat_applet_factory,
+                      NULL)

--- a/battstat/battstat_applet.c
+++ b/battstat/battstat_applet.c
@@ -1130,8 +1130,6 @@ battstat_applet_fill (MatePanelApplet *applet)
 
     if (DEBUG) g_print ("main ()\n");
 
-    g_set_application_name (_("Battery Charge Monitor"));
-
     gtk_window_set_default_icon_name ("battery");
 
     mate_panel_applet_set_flags (applet,
@@ -1210,7 +1208,7 @@ battstat_applet_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("BattstatAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("BattstatAppletFactory",
                                        PANEL_TYPE_APPLET,
                                        "battstat",
                                        battstat_applet_factory,

--- a/battstat/org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in.in
+++ b/battstat/org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=BattstatAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Battstat Factory
 Description=Battstat Factory
 

--- a/battstat/org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in.in
+++ b/battstat/org.mate.applets.BattstatApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=BattstatAppletFactory
-Location=@LIBEXECDIR@/battstat-applet
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Battstat Factory
 Description=Battstat Factory
 
@@ -10,6 +11,7 @@ Description=Monitor a laptop's remaining power
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=battery
 MateComponentId=OAFIID:MATE_BattstatApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=battery

--- a/battstat/org.mate.panel.applet.BattstatAppletFactory.service.in
+++ b/battstat/org.mate.panel.applet.BattstatAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.BattstatAppletFactory
+Exec=@APPLET_LOCATION@

--- a/battstat/org.mate.panel.applet.BattstatAppletFactory.service.in
+++ b/battstat/org.mate.panel.applet.BattstatAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.BattstatAppletFactory
-Exec=@LIBEXECDIR@/battstat-applet

--- a/charpick/Makefile.am
+++ b/charpick/Makefile.am
@@ -1,11 +1,10 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-charpick-applet.so
-
 SUBDIRS = help
 
-mate_charpick_applet_libdir= $(pkglibdir)
-mate_charpick_applet_lib_LTLIBRARIES=libmate-charpick-applet.la
+applet_in_files = org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.CharpickerAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.charpick.gschema.xml.in
 
 AM_CPPFLAGS =			\
 	-I.			\
@@ -16,18 +15,47 @@ AM_CPPFLAGS =			\
 	$(GUCHARMAP_CFLAGS)	\
 	$(NULL)
 
-libmate_charpick_applet_la_SOURCES = 	\
+BUILT_SOURCES =			\
+	charpick-resources.c	\
+	charpick-resources.h	\
+	$(NULL)
+APPLET_SOURCES =		\
 	charpick.c		\
 	charpick.h		\
 	properties.c		\
-	charpick-resources.c \
-	charpick-resources.h \
 	$(NULL)
 
-libmate_charpick_applet_la_LIBADD =	\
+APPLET_LIBS =			\
 	$(MATE_APPLETS4_LIBS)	\
 	$(GUCHARMAP_LIBS)	\
 	$(NULL)
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-charpick-applet.so
+
+pkglib_LTLIBRARIES = libmate-charpick-applet.la
+nodist_libmate_charpick_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_charpick_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_charpick_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_charpick_applet_la_LDFLAGS = -module -avoid-version
+libmate_charpick_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-charpick-applet
+
+libexec_PROGRAMS = mate-charpick-applet
+nodist_mate_charpick_applet_SOURCES = $(BUILT_SOURCES)
+mate_charpick_applet_SOURCES = $(APPLET_SOURCES)
+mate_charpick_applet_CFLAGS = $(AM_CFLAGS)
+mate_charpick_applet_LDADD = $(APPLET_LIBS)
+
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
 
 charpick-resources.c: charpick-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/charpick-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name charpick $<
@@ -36,32 +64,34 @@ charpick-resources.h: charpick-resources.gresource.xml $(shell $(GLIB_COMPILE_RE
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir) --generate --c-name charpick $<
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-charpick_gschema_in_files = org.mate.panel.applet.charpick.gschema.xml.in
-gsettings_SCHEMAS = $(charpick_gschema_in_files:.xml.in=.xml)
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 CLEANFILES =			\
 	$(applet_DATA)		\
 	$(applet_in_files)	\
+	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
+	$(BUILT_SOURCES)	\
 	*.gschema.valid		\
 	$(NULL)
 
 EXTRA_DIST =					\
 	$(applet_in_files).in			\
-	$(charpick_gschema_in_files)		\
+	$(service_in_files)			\
+	$(gschema_in_files)			\
 	charpick-applet-menu.xml		\
 	charpick-resources.gresource.xml	\
 	$(NULL)

--- a/charpick/Makefile.am
+++ b/charpick/Makefile.am
@@ -1,6 +1,11 @@
 NULL =
 
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-charpick-applet.so
+
 SUBDIRS = help
+
+mate_charpick_applet_libdir= $(pkglibdir)
+mate_charpick_applet_lib_LTLIBRARIES=libmate-charpick-applet.la
 
 AM_CPPFLAGS =			\
 	-I.			\
@@ -11,17 +16,15 @@ AM_CPPFLAGS =			\
 	$(GUCHARMAP_CFLAGS)	\
 	$(NULL)
 
-libexec_PROGRAMS = mate-charpick-applet
-
-BUILT_SOURCES = charpick-resources.c charpick-resources.h
-nodist_mate_charpick_applet_SOURCES = $(BUILT_SOURCES)
-mate_charpick_applet_SOURCES = 	\
+libmate_charpick_applet_la_SOURCES = 	\
 	charpick.c		\
 	charpick.h		\
 	properties.c		\
+	charpick-resources.c \
+	charpick-resources.h \
 	$(NULL)
 
-mate_charpick_applet_LDADD =	\
+libmate_charpick_applet_la_LIBADD =	\
 	$(MATE_APPLETS4_LIBS)	\
 	$(GUCHARMAP_LIBS)	\
 	$(NULL)
@@ -38,21 +41,12 @@ applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-ap
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
-            $< > $@
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
+		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
-
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.CharpickerAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.CharpickerAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 charpick_gschema_in_files = org.mate.panel.applet.charpick.gschema.xml.in
 gsettings_SCHEMAS = $(charpick_gschema_in_files:.xml.in=.xml)
@@ -61,15 +55,12 @@ gsettings_SCHEMAS = $(charpick_gschema_in_files:.xml.in=.xml)
 CLEANFILES =			\
 	$(applet_DATA)		\
 	$(applet_in_files)	\
-	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
-	$(BUILT_SOURCES)	\
 	*.gschema.valid		\
 	$(NULL)
 
 EXTRA_DIST =					\
 	$(applet_in_files).in			\
-	$(service_in_files)			\
 	$(charpick_gschema_in_files)		\
 	charpick-applet-menu.xml		\
 	charpick-resources.gresource.xml	\

--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -764,8 +764,6 @@ charpicker_applet_fill (MatePanelApplet *applet)
     gchar *string;
     GtkActionGroup *action_group;
 
-    g_set_application_name (_("Character Palette"));
-
     gtk_window_set_default_icon_name ("accessories-character-map");
 
     mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -872,7 +870,7 @@ charpicker_applet_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("CharpickerAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("CharpickerAppletFactory",
                                        PANEL_TYPE_APPLET,
                                        "char-palette",
                                        charpicker_applet_factory,

--- a/charpick/charpick.c
+++ b/charpick/charpick.c
@@ -764,6 +764,10 @@ charpicker_applet_fill (MatePanelApplet *applet)
     gchar *string;
     GtkActionGroup *action_group;
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Character Palette"));
+#endif
+
     gtk_window_set_default_icon_name ("accessories-character-map");
 
     mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -870,9 +874,9 @@ charpicker_applet_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("CharpickerAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "char-palette",
-                                       charpicker_applet_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("CharpickerAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "char-palette",
+                      charpicker_applet_factory,
+                      NULL)
 

--- a/charpick/org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in.in
+++ b/charpick/org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=CharpickerAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Charpicker Applet Factory
 Description=Charpicker Applet Factory
 

--- a/charpick/org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in.in
+++ b/charpick/org.mate.applets.CharpickerApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=CharpickerAppletFactory
-Location=@LIBEXECDIR@/mate-charpick-applet
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Charpicker Applet Factory
 Description=Charpicker Applet Factory
 
@@ -10,6 +11,7 @@ Description=Insert characters
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=accessories-character-map
 MateComponentId=OAFIID:MATE_CharpickerApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=charpick

--- a/charpick/org.mate.panel.applet.CharpickerAppletFactory.service.in
+++ b/charpick/org.mate.panel.applet.CharpickerAppletFactory.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.mate.panel.applet.CharpickerAppletFactory
-Exec=@LIBEXECDIR@/mate-charpick-applet
+Exec=@APPLET_LOCATION@

--- a/command/data/Makefile.am
+++ b/command/data/Makefile.am
@@ -1,4 +1,4 @@
-APPLET_LOCATION = $(libexecdir)/command-applet
+APPLET_LOCATION = $(libdir)/mate-applets/libcommand-applet.so
 
 appletsdir       = $(datadir)/mate-panel/applets
 applets_in_files = org.mate.applets.CommandApplet.mate-panel-applet.desktop.in
@@ -6,20 +6,12 @@ applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@
 
 $(applets_DATA): $(applets_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.CommandAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.CommandAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
-		$< > $@
 
 command_gschema_in_files = org.mate.panel.applet.command.gschema.xml.in
 gsettings_SCHEMAS = $(command_gschema_in_files:.xml.in=.xml)
@@ -27,7 +19,6 @@ gsettings_SCHEMAS = $(command_gschema_in_files:.xml.in=.xml)
 
 EXTRA_DIST = \
 	$(applets_in_files).in \
-	$(service_in_files) \
 	$(command_gschema_in_files) \
 	command-preferences.ui \
 	command-resources.gresource.xml
@@ -35,7 +26,6 @@ EXTRA_DIST = \
 CLEANFILES = \
 	$(applets_DATA) \
 	$(applets_in_files) \
-	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 

--- a/command/data/Makefile.am
+++ b/command/data/Makefile.am
@@ -1,31 +1,49 @@
-APPLET_LOCATION = $(libdir)/mate-applets/libcommand-applet.so
+applets_in_files = org.mate.applets.CommandApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.CommandAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.command.gschema.xml.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libcommand-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/command-applet
+endif !ENABLE_IN_PROCESS
 
 appletsdir       = $(datadir)/mate-panel/applets
-applets_in_files = org.mate.applets.CommandApplet.mate-panel-applet.desktop.in
 applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		$< > $@
 
 $(applets_DATA): $(applets_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
 
-command_gschema_in_files = org.mate.panel.applet.command.gschema.xml.in
-gsettings_SCHEMAS = $(command_gschema_in_files:.xml.in=.xml)
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 EXTRA_DIST = \
 	$(applets_in_files).in \
-	$(command_gschema_in_files) \
+	$(service_in_files) \
+	$(gschema_in_files) \
 	command-preferences.ui \
 	command-resources.gresource.xml
 
 CLEANFILES = \
 	$(applets_DATA) \
 	$(applets_in_files) \
+	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 

--- a/command/data/org.mate.applets.CommandApplet.mate-panel-applet.desktop.in.in
+++ b/command/data/org.mate.applets.CommandApplet.mate-panel-applet.desktop.in.in
@@ -1,11 +1,13 @@
 [Applet Factory]
 Id=CommandAppletFactory
-Location=@LOCATION@
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Command Factory
 Description=Command Factory
 
 [CommandApplet]
 Name=Command
 Description=Shows the output of a command
+Platforms=X11;Wayland;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=utilities-terminal

--- a/command/data/org.mate.applets.CommandApplet.mate-panel-applet.desktop.in.in
+++ b/command/data/org.mate.applets.CommandApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=CommandAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Command Factory
 Description=Command Factory
 

--- a/command/data/org.mate.panel.applet.CommandAppletFactory.service.in
+++ b/command/data/org.mate.panel.applet.CommandAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.CommandAppletFactory
+Exec=@APPLET_LOCATION@

--- a/command/data/org.mate.panel.applet.CommandAppletFactory.service.in
+++ b/command/data/org.mate.panel.applet.CommandAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.CommandAppletFactory
-Exec=@LOCATION@

--- a/command/src/Makefile.am
+++ b/command/src/Makefile.am
@@ -1,26 +1,40 @@
 NULL =
 
-command_applet_libdir= $(pkglibdir)
-command_applet_lib_LTLIBRARIES=libcommand-applet.la
-
 AM_CPPFLAGS =			\
+	$(WARN_FLAGS)		\
 	$(MATE_APPLETS4_CFLAGS)	\
 	-I$(srcdir)		\
 	$(DISABLE_DEPRECATED_CFLAGS) \
 	$(NULL)
 
-
-libcommand_applet_la_SOURCES =	\
-	command.c		\
-	ma-command.c		\
-	ma-command.h		\
+BUILT_SOURCES =			\
 	command-resources.c	\
 	command-resources.h	\
 	$(NULL)
+APPLET_SOURCES =	\
+	command.c	\
+	ma-command.c	\
+	ma-command.h	\
+	$(NULL)
 
-libcommand_applet_la_LIBADD =		\
+APPLET_LIBS =			\
 	$(MATE_APPLETS4_LIBS)	\
 	$(NULL)
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libcommand-applet.la
+nodist_libcommand_applet_la_SOURCES = $(BUILT_SOURCES)
+libcommand_applet_la_SOURCES = $(APPLET_SOURCES)
+libcommand_applet_la_CFLAGS = $(AM_CFLAGS)
+libcommand_applet_la_LDFLAGS = -module -avoid-version
+libcommand_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = command-applet
+nodist_command_applet_SOURCES = $(BUILT_SOURCES)
+command_applet_SOURCES = $(APPLET_SOURCES)
+command_applet_CFLAGS = $(AM_CFLAGS)
+command_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 command-resources.c: $(srcdir)/../data/command-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name command $<
@@ -29,6 +43,7 @@ command-resources.h: $(srcdir)/../data/command-resources.gresource.xml $(shell $
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name command $<
 
 CLEANFILES =			\
+	$(BUILT_SOURCES)
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/command/src/Makefile.am
+++ b/command/src/Makefile.am
@@ -1,34 +1,25 @@
 NULL =
 
+command_applet_libdir= $(pkglibdir)
+command_applet_lib_LTLIBRARIES=libcommand-applet.la
+
 AM_CPPFLAGS =			\
 	$(MATE_APPLETS4_CFLAGS)	\
 	-I$(srcdir)		\
 	$(DISABLE_DEPRECATED_CFLAGS) \
 	$(NULL)
 
-libexec_PROGRAMS = command-applet
 
-BUILT_SOURCES =			\
+libcommand_applet_la_SOURCES =	\
+	command.c		\
+	ma-command.c		\
+	ma-command.h		\
 	command-resources.c	\
 	command-resources.h	\
 	$(NULL)
 
-nodist_command_applet_SOURCES = \
-	$(BUILT_SOURCES)	\
-	$(NULL)
-
-command_applet_SOURCES =	\
-	command.c		\
-	ma-command.c		\
-	ma-command.h		\
-	$(NULL)
-
-command_applet_LDADD =		\
+libcommand_applet_la_LIBADD =		\
 	$(MATE_APPLETS4_LIBS)	\
-	$(NULL)
-
-command_applet_CFLAGS =		\
-	$(WARN_CFLAGS)		\
 	$(NULL)
 
 command-resources.c: $(srcdir)/../data/command-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/command-resources.gresource.xml)
@@ -38,7 +29,6 @@ command-resources.h: $(srcdir)/../data/command-resources.gresource.xml $(shell $
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name command $<
 
 CLEANFILES =			\
-	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/command/src/command.c
+++ b/command/src/command.c
@@ -418,6 +418,10 @@ command_applet_fill (MatePanelApplet* applet)
     CommandApplet *command_applet;
     AtkObject *atk_widget;
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Command Applet"));
+#endif
+
     gtk_window_set_default_icon_name (APPLET_ICON);
 
     mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -506,8 +510,8 @@ command_factory (MatePanelApplet* applet, const char* iid, gpointer data)
 }
 
 /* needed by mate-panel applet library */
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY("CommandAppletFactory",
-                                      PANEL_TYPE_APPLET,
-                                      "Command applet",
-                                      command_factory,
-                                      NULL)
+PANEL_APPLET_FACTORY ("CommandAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "Command applet",
+                      command_factory,
+                      NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -512,6 +512,27 @@ if test "$gtk_ok" = "yes"; then
             [Define if _NL_MEASUREMENT_MEASUREMENT is available])
 fi
 
+AC_ARG_ENABLE([in-process],
+              [AS_HELP_STRING([--enable-in-process],
+                              [Build all applets in-process])],
+              [enable_in_process=$enableval],
+              [enable_in_process=no])
+
+# Automake conditional on whether to build in-process
+AM_CONDITIONAL([ENABLE_IN_PROCESS], [test "x$enable_in_process" = "xyes"])
+# Automake value expected to be substitued in .mate-panel-apple.* for the value of "InProcess"
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_SUBST([APPLET_IN_PROCESS], [true])],
+      [AC_SUBST([APPLET_IN_PROCESS], [false])])
+# C conditional on whether to build in-process
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [AC_DEFINE([ENABLE_IN_PROCESS], [1], [building in-process])])
+# Convenience C define selecting the right applet factory
+AS_IF([test "x$enable_in_process" = "xyes"],
+      [factory=MATE_PANEL_APPLET_IN_PROCESS_FACTORY],
+      [factory=MATE_PANEL_APPLET_OUT_PROCESS_FACTORY])
+AC_DEFINE_UNQUOTED([PANEL_APPLET_FACTORY], [$factory], [Panel applet factory])
+
 dnl ***************************************************************************
 dnl *** Honour aclocal flags                                                ***
 dnl ***************************************************************************
@@ -656,4 +677,5 @@ Configure summary:
     Using UPOWER:                  $HAVE_UPOWER
     Using libnotify:               $HAVE_LIBNOTIFY
     Enabling IPv6:                 $have_ipv6
+    Build in-process:              $enable_in_process
 " >&2

--- a/cpufreq/data/Makefile.am
+++ b/cpufreq/data/Makefile.am
@@ -4,39 +4,31 @@ cpufreq_gschema_in_files = org.mate.panel.applet.cpufreq.gschema.xml.in
 gsettings_SCHEMAS = $(cpufreq_gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
+APPLET_LOCATION = $(libdir)/mate-applets/libmatecpufreqapplet.so
+
 appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
-            $< > $@
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
+		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.CPUFreqAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.CPUFreqAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 CLEANFILES =				\
 	$(applet_DATA)			\
 	$(applet_in_files)		\
-	$(service_DATA)			\
 	$(gsettings_SCHEMAS)		\
 	*.gschema.valid			\
 	$(NULL)
 
 EXTRA_DIST =				\
 	$(applet_in_files).in		\
-	$(service_in_files)		\
 	$(cpufreq_gschema_in_files)	\
 	cpufreq-applet-menu.xml		\
 	cpufreq-preferences.ui		\

--- a/cpufreq/data/Makefile.am
+++ b/cpufreq/data/Makefile.am
@@ -1,35 +1,53 @@
 NULL =
 
-cpufreq_gschema_in_files = org.mate.panel.applet.cpufreq.gschema.xml.in
-gsettings_SCHEMAS = $(cpufreq_gschema_in_files:.xml.in=.xml)
+applet_in_files = org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.CPUFreqAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.cpufreq.gschema.xml.in
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmatecpufreqapplet.so
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-cpufreq-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-cpufreq-applet
+endif !ENABLE_IN_PROCESS
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
 
 CLEANFILES =				\
 	$(applet_DATA)			\
 	$(applet_in_files)		\
+	$(service_DATA)			\
 	$(gsettings_SCHEMAS)		\
 	*.gschema.valid			\
 	$(NULL)
 
 EXTRA_DIST =				\
 	$(applet_in_files).in		\
-	$(cpufreq_gschema_in_files)	\
+	$(service_in_files)		\
+	$(gschema_in_files)		\
 	cpufreq-applet-menu.xml		\
 	cpufreq-preferences.ui		\
 	cpufreq-resources.gresource.xml	\

--- a/cpufreq/data/org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in.in
+++ b/cpufreq/data/org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=CPUFreqAppletFactory
-Location=@LIBEXECDIR@/mate-cpufreq-applet
+InProcess=true
+Location=@APPLET_LOCATION@
 Name=CPU Frequency Scaling Monitor
 Description=Monitor the CPU Frequency Scaling
 

--- a/cpufreq/data/org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in.in
+++ b/cpufreq/data/org.mate.applets.CPUFreqApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,6 @@
 [Applet Factory]
 Id=CPUFreqAppletFactory
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Location=@APPLET_LOCATION@
 Name=CPU Frequency Scaling Monitor
 Description=Monitor the CPU Frequency Scaling

--- a/cpufreq/data/org.mate.panel.applet.CPUFreqAppletFactory.service.in
+++ b/cpufreq/data/org.mate.panel.applet.CPUFreqAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.CPUFreqAppletFactory
+Exec=@APPLET_LOCATION@

--- a/cpufreq/data/org.mate.panel.applet.CPUFreqAppletFactory.service.in
+++ b/cpufreq/data/org.mate.panel.applet.CPUFreqAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.CPUFreqAppletFactory
-Exec=@LIBEXECDIR@/mate-cpufreq-applet

--- a/cpufreq/src/Makefile.am
+++ b/cpufreq/src/Makefile.am
@@ -5,68 +5,70 @@ endif
 SUBDIRS = $(selector_SUBDIR)
 
 AM_CPPFLAGS = \
-	$(MATE_APPLETS4_CFLAGS)
-
-cpufreq_libdir= $(pkglibdir)
-cpufreq_lib_LTLIBRARIES=libmatecpufreqapplet.la
-
-libmatecpufreqapplet_la_CPPFLAGS = \
-	-I$(top_builddir) \
-	-I$(top_srcdir) \
-	-DGTK_BUILDERDIR=\""$(pkgdatadir)/builder"\" \
 	-DCPUFREQ_RESOURCE_PATH=\""/org/mate/mate-applets/cpufreq/"\" \
 	$(NULL)
 
-libmatecpufreqapplet_la_CFLAGS = \
+AM_CFLAGS =				\
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(GIO_CFLAGS) \
 	$(WARN_CFLAGS) \
-	$(AM_CFLAGS) \
 	$(NULL)
 
-libmatecpufreqapplet_la_SOURCES = \
-	cpufreq-applet.c        \
-    cpufreq-applet.h        \
+BUILT_SOURCES = 		\
+	cpufreq-resources.c	\
+	cpufreq-resources.h	\
+	$(NULL)
+APPLET_SOURCES =			\
+	cpufreq-applet.c		\
+	cpufreq-applet.h		\
 	cpufreq-utils.c			\
-    cpufreq-utils.h			\
-	cpufreq-prefs.c         \
-    cpufreq-prefs.h         \
+	cpufreq-utils.h			\
+	cpufreq-prefs.c			\
+	cpufreq-prefs.h			\
 	cpufreq-selector.c		\
-    cpufreq-selector.h		\
-	cpufreq-popup.c         \
-    cpufreq-popup.h			\
-	cpufreq-monitor.c       \
-    cpufreq-monitor.h	    \
+	cpufreq-selector.h		\
+	cpufreq-popup.c			\
+	cpufreq-popup.h			\
+	cpufreq-monitor.c		\
+	cpufreq-monitor.h		\
 	cpufreq-monitor-factory.c	\
-    cpufreq-monitor-factory.h   \
-    cpufreq-resources.c     \
-    cpufreq-resources.h    \
+	cpufreq-monitor-factory.h	\
 	$(NULL)
 
-libmatecpufreqapplet_la_LDFLAGS = \
-	-module -avoid-version \
-	$(WARN_LDFLAGS) \
-	$(AM_LDFLAGS) \
+if HAVE_LIBCPUFREQ
+APPLET_SOURCES +=			\
+	cpufreq-monitor-libcpufreq.c	\
+	cpufreq-monitor-libcpufreq.h	\
 	$(NULL)
+else
+APPLET_SOURCES +=			\
+	cpufreq-monitor-cpuinfo.c	\
+	cpufreq-monitor-cpuinfo.h	\
+	cpufreq-monitor-sysfs.c		\
+	cpufreq-monitor-sysfs.h		\
+	$(NULL)
+endif
 
-libmatecpufreqapplet_la_LIBADD = \
+APPLET_LIBS = \
 	$(MATE_APPLETS4_LIBS)		\
 	$(LIBCPUFREQ_LIBS) \
 	$(NULL)
 
-if HAVE_LIBCPUFREQ
-libmatecpufreqapplet_la_SOURCES += \
-	cpufreq-monitor-libcpufreq.c \
-	cpufreq-monitor-libcpufreq.h \
-	$(NULL)
-else
-libmatecpufreqapplet_la_SOURCES += \
-	cpufreq-monitor-cpuinfo.c \
-	cpufreq-monitor-cpuinfo.h \
-	cpufreq-monitor-sysfs.c \
-	cpufreq-monitor-sysfs.h \
-	$(NULL)
-endif
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-cpufreq-applet.la
+nodist_libmate_cpufreq_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_cpufreq_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_cpufreq_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_cpufreq_applet_la_LDFLAGS = -module -avoid-version
+libmate_cpufreq_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mate-cpufreq-applet
+nodist_mate_cpufreq_applet_SOURCES = $(BUILT_SOURCES)
+mate_cpufreq_applet_SOURCES = $(APPLET_SOURCES)
+mate_cpufreq_applet_CFLAGS = $(AM_CFLAGS)
+mate_cpufreq_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 cpufreq-resources.c: $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq/data --generate-dependencies $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq/data --generate --c-name cpufreq $<
@@ -75,8 +77,7 @@ cpufreq-resources.h: $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml 
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq/data --generate --c-name cpufreq $<
 
 CLEANFILES = \
-	cpufreq-resources.c		\
-	cpufreq-resources.h     \
+	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/cpufreq/src/Makefile.am
+++ b/cpufreq/src/Makefile.am
@@ -5,44 +5,68 @@ endif
 SUBDIRS = $(selector_SUBDIR)
 
 AM_CPPFLAGS = \
-	-DCPUFREQ_RESOURCE_PATH=\""/org/mate/mate-applets/cpufreq/"\" \
 	$(MATE_APPLETS4_CFLAGS)
 
-libexec_PROGRAMS = mate-cpufreq-applet
+cpufreq_libdir= $(pkglibdir)
+cpufreq_lib_LTLIBRARIES=libmatecpufreqapplet.la
 
-BUILT_SOURCES = \
-	cpufreq-resources.c		cpufreq-resources.h
+libmatecpufreqapplet_la_CPPFLAGS = \
+	-I$(top_builddir) \
+	-I$(top_srcdir) \
+	-DGTK_BUILDERDIR=\""$(pkgdatadir)/builder"\" \
+	-DCPUFREQ_RESOURCE_PATH=\""/org/mate/mate-applets/cpufreq/"\" \
+	$(NULL)
 
-nodist_mate_cpufreq_applet_SOURCES = \
-	$(BUILT_SOURCES)
+libmatecpufreqapplet_la_CFLAGS = \
+	$(MATE_APPLETS4_CFLAGS)		\
+	$(GIO_CFLAGS) \
+	$(WARN_CFLAGS) \
+	$(AM_CFLAGS) \
+	$(NULL)
 
-mate_cpufreq_applet_SOURCES = \
-	cpufreq-applet.c        	cpufreq-applet.h        	\
-	cpufreq-utils.c			cpufreq-utils.h			\
-	cpufreq-prefs.c         	cpufreq-prefs.h         	\
-	cpufreq-selector.c		cpufreq-selector.h		\
-	cpufreq-popup.c                 cpufreq-popup.h			\
-	cpufreq-monitor.c       	cpufreq-monitor.h	      	\
-	cpufreq-monitor-factory.c	cpufreq-monitor-factory.h
+libmatecpufreqapplet_la_SOURCES = \
+	cpufreq-applet.c        \
+    cpufreq-applet.h        \
+	cpufreq-utils.c			\
+    cpufreq-utils.h			\
+	cpufreq-prefs.c         \
+    cpufreq-prefs.h         \
+	cpufreq-selector.c		\
+    cpufreq-selector.h		\
+	cpufreq-popup.c         \
+    cpufreq-popup.h			\
+	cpufreq-monitor.c       \
+    cpufreq-monitor.h	    \
+	cpufreq-monitor-factory.c	\
+    cpufreq-monitor-factory.h   \
+    cpufreq-resources.c     \
+    cpufreq-resources.h    \
+	$(NULL)
+
+libmatecpufreqapplet_la_LDFLAGS = \
+	-module -avoid-version \
+	$(WARN_LDFLAGS) \
+	$(AM_LDFLAGS) \
+	$(NULL)
+
+libmatecpufreqapplet_la_LIBADD = \
+	$(MATE_APPLETS4_LIBS)		\
+	$(LIBCPUFREQ_LIBS) \
+	$(NULL)
 
 if HAVE_LIBCPUFREQ
-mate_cpufreq_applet_SOURCES += \
+libmatecpufreqapplet_la_SOURCES += \
 	cpufreq-monitor-libcpufreq.c \
-	cpufreq-monitor-libcpufreq.h
+	cpufreq-monitor-libcpufreq.h \
+	$(NULL)
 else
-mate_cpufreq_applet_SOURCES += \
+libmatecpufreqapplet_la_SOURCES += \
 	cpufreq-monitor-cpuinfo.c \
 	cpufreq-monitor-cpuinfo.h \
 	cpufreq-monitor-sysfs.c \
-	cpufreq-monitor-sysfs.h
+	cpufreq-monitor-sysfs.h \
+	$(NULL)
 endif
-
-mate_cpufreq_applet_CFLAGS =		\
-	${WARN_CFLAGS}
-
-mate_cpufreq_applet_LDADD =		\
-	$(MATE_APPLETS4_LIBS)   	\
-	$(LIBCPUFREQ_LIBS)
 
 cpufreq-resources.c: $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(top_srcdir)/cpufreq/data --generate-dependencies $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq/data --generate --c-name cpufreq $<
@@ -51,6 +75,8 @@ cpufreq-resources.h: $(top_srcdir)/cpufreq/data/cpufreq-resources.gresource.xml 
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(top_srcdir)/cpufreq/data --generate --c-name cpufreq $<
 
 CLEANFILES = \
-	$(BUILT_SOURCES)
+	cpufreq-resources.c		\
+	cpufreq-resources.h     \
+	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -787,8 +787,6 @@ cpufreq_applet_setup (CPUFreqApplet *applet)
     AtkObject      *atk_obj;
     GSettings      *settings;
 
-    g_set_application_name  (_("CPU Frequency Scaling Monitor"));
-
     gtk_window_set_default_icon_name ("mate-cpu-frequency-applet");
 
     /* Preferences */
@@ -867,7 +865,7 @@ cpufreq_applet_factory (CPUFreqApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("CPUFreqAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("CPUFreqAppletFactory",
                                        CPUFREQ_TYPE_APPLET,
                                        "cpufreq-applet",
                                        (MatePanelAppletFactoryCallback) cpufreq_applet_factory,

--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -787,6 +787,10 @@ cpufreq_applet_setup (CPUFreqApplet *applet)
     AtkObject      *atk_obj;
     GSettings      *settings;
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name  (_("CPU Frequency Scaling Monitor"));
+#endif
+
     gtk_window_set_default_icon_name ("mate-cpu-frequency-applet");
 
     /* Preferences */
@@ -865,8 +869,8 @@ cpufreq_applet_factory (CPUFreqApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("CPUFreqAppletFactory",
-                                       CPUFREQ_TYPE_APPLET,
-                                       "cpufreq-applet",
-                                       (MatePanelAppletFactoryCallback) cpufreq_applet_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("CPUFreqAppletFactory",
+                      CPUFREQ_TYPE_APPLET,
+                      "cpufreq-applet",
+                      (MatePanelAppletFactoryCallback) cpufreq_applet_factory,
+                      NULL)

--- a/drivemount/data/Makefile.am
+++ b/drivemount/data/Makefile.am
@@ -1,36 +1,55 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-drivemount-applet.so
+applet_in_files = org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.DriveMountAppletFactory.service.in
+gschema_in_files = org.mate.drivemount.gschema.xml.in
 
-drivemount_gschema_in_files = org.mate.drivemount.gschema.xml.in
-gsettings_SCHEMAS = $(drivemount_gschema_in_files:.xml.in=.xml)
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-drivemount-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-drivemount-applet
+endif !ENABLE_IN_PROCESS
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
             -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+            -e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
+
 CLEANFILES =				\
 	$(applet_DATA)			\
 	$(applet_in_files)		\
+	$(service_DATA)			\
 	$(gsettings_SCHEMAS)		\
 	*.gschema.valid			\
 	$(NULL)
 
-EXTRA_DIST =				\
-	$(applet_in_files:=.in)		\
-	$(drivemount_gschema_in_files)	\
-	drivemount-applet-menu.xml	\
-	drivemount-resources.gresource.xml \
+EXTRA_DIST =					\
+	$(applet_in_files:=.in)			\
+	$(gschema_in_files)			\
+	$(service_in_files)			\
+	drivemount-applet-menu.xml		\
+	drivemount-resources.gresource.xml	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/drivemount/data/Makefile.am
+++ b/drivemount/data/Makefile.am
@@ -1,5 +1,7 @@
 NULL =
 
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-drivemount-applet.so
+
 drivemount_gschema_in_files = org.mate.drivemount.gschema.xml.in
 gsettings_SCHEMAS = $(drivemount_gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
@@ -10,26 +12,16 @@ applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-ap
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.DriveMountAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.DriveMountAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
-
 CLEANFILES =				\
 	$(applet_DATA)			\
 	$(applet_in_files)		\
-	$(service_DATA)			\
 	$(gsettings_SCHEMAS)		\
 	*.gschema.valid			\
 	$(NULL)
@@ -37,7 +29,6 @@ CLEANFILES =				\
 EXTRA_DIST =				\
 	$(applet_in_files:=.in)		\
 	$(drivemount_gschema_in_files)	\
-	$(service_in_files)		\
 	drivemount-applet-menu.xml	\
 	drivemount-resources.gresource.xml \
 	$(NULL)

--- a/drivemount/data/org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in.in
+++ b/drivemount/data/org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=DriveMountAppletFactory
-Location=@LIBEXECDIR@/mate-drivemount-applet
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Drive Mount Applet Factory
 Description=Factory for drive mount applet
 
@@ -10,6 +11,7 @@ Description=Mount local disks and devices
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=media-floppy
 MateComponentId=OAFIID:MATE_DriveMountApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=Disk Mounter (drivemount)

--- a/drivemount/data/org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in.in
+++ b/drivemount/data/org.mate.applets.DriveMountApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=DriveMountAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Drive Mount Applet Factory
 Description=Factory for drive mount applet
 

--- a/drivemount/data/org.mate.panel.applet.DriveMountAppletFactory.service.in
+++ b/drivemount/data/org.mate.panel.applet.DriveMountAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.DriveMountAppletFactory
-Exec=@LIBEXECDIR@/mate-drivemount-applet

--- a/drivemount/data/org.mate.panel.applet.DriveMountAppletFactory.service.in
+++ b/drivemount/data/org.mate.panel.applet.DriveMountAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.DriveMountAppletFactory
+Exec=@APPLET_LOCATION@

--- a/drivemount/src/Makefile.am
+++ b/drivemount/src/Makefile.am
@@ -1,5 +1,8 @@
 NULL =
 
+mate_drivemount_applet_libdir= $(pkglibdir)
+mate_drivemount_applet_lib_LTLIBRARIES=libmate-drivemount-applet.la
+
 AM_CPPFLAGS =				\
 	-I.				\
 	-I$(srcdir)			\
@@ -8,26 +11,17 @@ AM_CPPFLAGS =				\
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(NULL)
 
-libexec_PROGRAMS = mate-drivemount-applet
-
-BUILT_SOURCES =				\
-	drivemount-resources.c		\
-	drivemount-resources.h		\
-	$(NULL)
-
-nodist_mate_drivemount_applet_SOURCES =	\
-	$(BUILT_SOURCES)		\
-	$(NULL)
-
-mate_drivemount_applet_SOURCES =	\
+libmate_drivemount_applet_la_SOURCES =	\
 	drivemount.c			\
 	drive-list.c			\
 	drive-list.h			\
 	drive-button.c			\
 	drive-button.h			\
+	drivemount-resources.c		\
+	drivemount-resources.h		\
 	$(NULL)
 
-mate_drivemount_applet_LDADD =		\
+libmate_drivemount_applet_la_LIBADD =		\
 	$(MATE_APPLETS4_LIBS)
 
 drivemount-resources.c: ../data/drivemount-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml)
@@ -37,7 +31,6 @@ drivemount-resources.h: ../data/drivemount-resources.gresource.xml $(shell $(GLI
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name drivemount $<
 
 CLEANFILES =				\
-	$(BUILT_SOURCES)		\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/drivemount/src/Makefile.am
+++ b/drivemount/src/Makefile.am
@@ -1,8 +1,5 @@
 NULL =
 
-mate_drivemount_applet_libdir= $(pkglibdir)
-mate_drivemount_applet_lib_LTLIBRARIES=libmate-drivemount-applet.la
-
 AM_CPPFLAGS =				\
 	-I.				\
 	-I$(srcdir)			\
@@ -11,18 +8,34 @@ AM_CPPFLAGS =				\
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(NULL)
 
-libmate_drivemount_applet_la_SOURCES =	\
+BUILT_SOURCES =				\
+	drivemount-resources.c		\
+	drivemount-resources.h		\
+	$(NULL)
+APPLET_SOURCES =			\
 	drivemount.c			\
 	drive-list.c			\
 	drive-list.h			\
 	drive-button.c			\
 	drive-button.h			\
-	drivemount-resources.c		\
-	drivemount-resources.h		\
 	$(NULL)
 
-libmate_drivemount_applet_la_LIBADD =		\
-	$(MATE_APPLETS4_LIBS)
+APPLET_LIBS = $(MATE_APPLETS4_LIBS)
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-drivemount-applet.la
+nodist_libmate_drivemount_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_drivemount_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_drivemount_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_drivemount_applet_la_LDFLAGS = -module -avoid-version
+libmate_drivemount_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mate-drivemount-applet
+nodist_mate_drivemount_applet_SOURCES = $(BUILT_SOURCES)
+mate_drivemount_applet_SOURCES = $(APPLET_SOURCES)
+mate_drivemount_applet_CFLAGS = $(AM_CFLAGS)
+mate_drivemount_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 drivemount-resources.c: ../data/drivemount-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/drivemount-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name drivemount $<
@@ -31,6 +44,7 @@ drivemount-resources.h: ../data/drivemount-resources.gresource.xml $(shell $(GLI
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name drivemount $<
 
 CLEANFILES =				\
+	$(BUILT_SOURCES)		\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/drivemount/src/drivemount.c
+++ b/drivemount/src/drivemount.c
@@ -179,8 +179,6 @@ applet_factory (MatePanelApplet *applet,
     GtkActionGroup *action_group;
 
     if (!strcmp (iid, drivemount_iid)) {
-        g_set_application_name (_("Disk Mounter"));
-
         gtk_window_set_default_icon_name ("media-floppy");
 
         mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -223,7 +221,7 @@ applet_factory (MatePanelApplet *applet,
     return ret;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY (factory_iid,
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY (factory_iid,
                                        PANEL_TYPE_APPLET,
                                        "Drive-Mount-Applet",
                                        applet_factory, NULL)

--- a/drivemount/src/drivemount.c
+++ b/drivemount/src/drivemount.c
@@ -179,6 +179,10 @@ applet_factory (MatePanelApplet *applet,
     GtkActionGroup *action_group;
 
     if (!strcmp (iid, drivemount_iid)) {
+#ifndef ENABLE_IN_PROCESS
+        g_set_application_name (_("Disk Mounter"));
+#endif
+
         gtk_window_set_default_icon_name ("media-floppy");
 
         mate_panel_applet_set_flags (applet, MATE_PANEL_APPLET_EXPAND_MINOR);
@@ -221,8 +225,7 @@ applet_factory (MatePanelApplet *applet,
     return ret;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY (factory_iid,
-                                       PANEL_TYPE_APPLET,
-                                       "Drive-Mount-Applet",
-                                       applet_factory, NULL)
-
+PANEL_APPLET_FACTORY (factory_iid,
+                      PANEL_TYPE_APPLET,
+                      "Drive-Mount-Applet",
+                      applet_factory, NULL)

--- a/geyes/data/Makefile.am
+++ b/geyes/data/Makefile.am
@@ -1,29 +1,39 @@
 NULL =
 
-appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.GeyesApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.GeyesAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.geyes.gschema.xml.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-geyes-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-geyes-applet
+endif !ENABLE_IN_PROCESS
+
+appletdir       = $(datadir)/mate-panel/applets
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+            -e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
 servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.GeyesAppletFactory.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 
-org.mate.panel.applet.GeyesAppletFactory.service: $(service_in_files)
+$(service_DATA): $(service_in_files) Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
             $< > $@
+endif !ENABLE_IN_PROCESS
 
-geyes_gschema_in_files = org.mate.panel.applet.geyes.gschema.xml.in
-gsettings_SCHEMAS = $(geyes_gschema_in_files:.xml.in=.xml)
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 CLEANFILES = \
@@ -40,7 +50,7 @@ EXTRA_DIST = \
 	themes.ui			\
 	$(applet_in_files).in		\
 	$(service_in_files)		\
-	$(geyes_gschema_in_files)	\
+	$(gschema_in_files)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/geyes/data/org.mate.applets.GeyesApplet.mate-panel-applet.desktop.in.in
+++ b/geyes/data/org.mate.applets.GeyesApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=GeyesAppletFactory
-Location=@LIBEXECDIR@/mate-geyes-applet
+Location=@APPLET_LOCATION@
+InProcess=@APPLET_IN_PROCESS@
 Name=Eyes Applet Factory
 Description=Eyes Applet Factory
 
@@ -10,6 +11,7 @@ Description=A set of eyeballs for your panel
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-eyes-applet
 MateComponentId=OAFIID:MATE_GeyesApplet
+Platforms=X11;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=geyes

--- a/geyes/data/org.mate.panel.applet.GeyesAppletFactory.service.in
+++ b/geyes/data/org.mate.panel.applet.GeyesAppletFactory.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.mate.panel.applet.GeyesAppletFactory
-Exec=@LIBEXECDIR@/mate-geyes-applet
+Exec=@APPLET_LOCATION@

--- a/geyes/src/Makefile.am
+++ b/geyes/src/Makefile.am
@@ -9,19 +9,30 @@ AM_CPPFLAGS =						\
 	-DGEYES_RESOURCE_PATH=\""/org/mate/mate-applets/eyes/"\" \
 	${WARN_CFLAGS}
 
-libexec_PROGRAMS = mate-geyes-applet
-
 BUILT_SOURCES = geyes-resources.c geyes-resources.h
-nodist_mate_geyes_applet_SOURCES = $(BUILT_SOURCES)
-mate_geyes_applet_SOURCES =	\
+APPLET_SOURCES =		\
 	geyes.c			\
 	geyes.h			\
 	themes.c		\
 	$(NULL)
-
-mate_geyes_applet_LDADD =	\
+APPLET_LIBS =			\
 	$(MATE_APPLETS4_LIBS)	\
 	-lm
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-geyes-applet.la
+nodist_libmate_geyes_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_geyes_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_geyes_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_geyes_applet_la_LDFLAGS = -module -avoid-version
+libmate_geyes_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mate-geyes-applet
+nodist_mate_geyes_applet_SOURCES = $(BUILT_SOURCES)
+mate_geyes_applet_SOURCES = $(APPLET_SOURCES)
+mate_geyes_applet_CFLAGS = $(AM_CFLAGS)
+mate_geyes_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 geyes-resources.c: $(srcdir)/../data/geyes-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/geyes-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name eyes $<

--- a/geyes/src/geyes.c
+++ b/geyes/src/geyes.c
@@ -140,8 +140,10 @@ timer_cb (EyesApplet *eyes_applet)
     display = gtk_widget_get_display (GTK_WIDGET (eyes_applet->applet));
     seat = gdk_display_get_default_seat (display);
 
-    for (i = 0; i < eyes_applet->num_eyes; i++) {
-        if (gtk_widget_get_realized (eyes_applet->eyes[i])) {
+    for (i = 0; i < eyes_applet->num_eyes; i++)
+    {
+        if (gtk_widget_get_realized (eyes_applet->eyes[i]))
+        {
             gdk_window_get_device_position (gtk_widget_get_window (eyes_applet->eyes[i]),
                                             gdk_seat_get_pointer (seat),
                                             &x, &y, NULL);

--- a/mateweather/data/Makefile.am
+++ b/mateweather/data/Makefile.am
@@ -1,36 +1,29 @@
+APPLET_LOCATION = $(libdir)/mate-applets/libmateweather-applet.so
+
 appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.MateWeatherAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
 
-org.mate.panel.applet.MateWeatherAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 CLEANFILES =			\
 	$(applet_DATA)		\
-	$(applet_in_files)	\
-	$(service_DATA)
+	$(applet_in_files)
 
 EXTRA_DIST =					\
 	mateweather-applet-menu.xml		\
 	mateweather-dialog.ui			\
 	mateweather-resources.gresource.xml	\
 	$(applet_in_files:=.in)			\
-	$(service_in_files)			\
 	$(ui_DATA)
 
 -include $(top_srcdir)/git.mk

--- a/mateweather/data/Makefile.am
+++ b/mateweather/data/Makefile.am
@@ -1,29 +1,47 @@
-APPLET_LOCATION = $(libdir)/mate-applets/libmateweather-applet.so
+applet_in_files = org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.MateWeatherAppletFactory.service.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmateweather-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mateweather-applet
+endif !ENABLE_IN_PROCESS
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
             -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+            -e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
 
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
 
 CLEANFILES =			\
 	$(applet_DATA)		\
-	$(applet_in_files)
+	$(applet_in_files)	\
+	$(service_DATA)		\
+	$(NULL)
 
 EXTRA_DIST =					\
 	mateweather-applet-menu.xml		\
 	mateweather-dialog.ui			\
 	mateweather-resources.gresource.xml	\
 	$(applet_in_files:=.in)			\
+	$(service_in_files)			\
 	$(ui_DATA)
 
 -include $(top_srcdir)/git.mk

--- a/mateweather/data/org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in.in
+++ b/mateweather/data/org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=MateWeatherAppletFactory
-Location=@LIBEXECDIR@/mateweather-applet
+InProcess=true
+Location=@APPLET_LOCATION@
 Name=Mateweather Applet Factory
 Description=Factory for creating the weather applet.
 
@@ -10,6 +11,7 @@ Description=Monitor the current weather conditions, and forecasts
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=weather-storm
 MateComponentId=OAFIID:MATE_MateWeatherApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=mateweather

--- a/mateweather/data/org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in.in
+++ b/mateweather/data/org.mate.applets.MateWeatherApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,6 @@
 [Applet Factory]
 Id=MateWeatherAppletFactory
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Location=@APPLET_LOCATION@
 Name=Mateweather Applet Factory
 Description=Factory for creating the weather applet.

--- a/mateweather/data/org.mate.panel.applet.MateWeatherAppletFactory.service.in
+++ b/mateweather/data/org.mate.panel.applet.MateWeatherAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.MateWeatherAppletFactory
+Exec=@APPLET_LOCATION@

--- a/mateweather/data/org.mate.panel.applet.MateWeatherAppletFactory.service.in
+++ b/mateweather/data/org.mate.panel.applet.MateWeatherAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.MateWeatherAppletFactory
-Exec=@LIBEXECDIR@/mateweather-applet

--- a/mateweather/src/Makefile.am
+++ b/mateweather/src/Makefile.am
@@ -1,3 +1,8 @@
+NULL =
+
+mateweather_applet_libdir= $(pkglibdir)
+mateweather_applet_lib_LTLIBRARIES=libmateweather-applet.la
+
 AM_CPPFLAGS =					\
 	-I$(srcdir)				\
 	-I$(top_srcdir)				\
@@ -7,23 +12,23 @@ AM_CPPFLAGS =					\
 	$(LIBMATEWEATHER_CFLAGS)		\
 	${WARN_CFLAGS}
 
-libexec_PROGRAMS = mateweather-applet
-
-BUILT_SOURCES = mateweather-resources.c mateweather-resources.h
-nodist_mateweather_applet_SOURCES = $(BUILT_SOURCES)
-mateweather_applet_SOURCES = \
+libmateweather_applet_la_SOURCES = \
 	mateweather.h \
 	main.c \
 	mateweather-about.c mateweather-about.h \
 	mateweather-pref.c mateweather-pref.h \
 	mateweather-dialog.c mateweather-dialog.h \
-	mateweather-applet.c mateweather-applet.h
+	mateweather-applet.c mateweather-applet.h \
+	mateweather-resources.c \
+	mateweather-resources.h \
+	$(NULL)
 
-mateweather_applet_LDADD = 	\
+libmateweather_applet_la_LIBADD = 	\
 	$(LIBNOTIFY_LIBS) 	\
 	$(MATE_APPLETS4_LIBS)	\
 	$(MATE_LIBS2_LIBS)	\
-	$(LIBMATEWEATHER_LIBS)
+	$(LIBMATEWEATHER_LIBS) \
+	$(NULL)
 
 mateweather-resources.c: ../data/mateweather-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name mateweather $<

--- a/mateweather/src/Makefile.am
+++ b/mateweather/src/Makefile.am
@@ -1,8 +1,5 @@
 NULL =
 
-mateweather_applet_libdir= $(pkglibdir)
-mateweather_applet_lib_LTLIBRARIES=libmateweather-applet.la
-
 AM_CPPFLAGS =					\
 	-I$(srcdir)				\
 	-I$(top_srcdir)				\
@@ -12,23 +9,40 @@ AM_CPPFLAGS =					\
 	$(LIBMATEWEATHER_CFLAGS)		\
 	${WARN_CFLAGS}
 
-libmateweather_applet_la_SOURCES = \
-	mateweather.h \
-	main.c \
-	mateweather-about.c mateweather-about.h \
-	mateweather-pref.c mateweather-pref.h \
-	mateweather-dialog.c mateweather-dialog.h \
-	mateweather-applet.c mateweather-applet.h \
-	mateweather-resources.c \
-	mateweather-resources.h \
+BUILT_SOURCES =			\
+	mateweather-resources.c	\
+	mateweather-resources.h	\
+	$(NULL)
+APPLET_SOURCES =					\
+	mateweather.h					\
+	main.c						\
+	mateweather-about.c mateweather-about.h		\
+	mateweather-pref.c mateweather-pref.h		\
+	mateweather-dialog.c mateweather-dialog.h	\
+	mateweather-applet.c mateweather-applet.h	\
 	$(NULL)
 
-libmateweather_applet_la_LIBADD = 	\
+APPLET_LIBS =			\
 	$(LIBNOTIFY_LIBS) 	\
 	$(MATE_APPLETS4_LIBS)	\
 	$(MATE_LIBS2_LIBS)	\
-	$(LIBMATEWEATHER_LIBS) \
+	$(LIBMATEWEATHER_LIBS)	\
 	$(NULL)
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmateweather-applet.la
+nodist_libmateweather_applet_la_SOURCES = $(BUILT_SOURCES)
+libmateweather_applet_la_SOURCES = $(APPLET_SOURCES)
+libmateweather_applet_la_CFLAGS = $(AM_CFLAGS)
+libmateweather_applet_la_LDFLAGS = -module -avoid-version
+libmateweather_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mateweather-applet
+nodist_mateweather_applet_SOURCES = $(BUILT_SOURCES)
+mateweather_applet_SOURCES = $(APPLET_SOURCES)
+mateweather_applet_CFLAGS = $(AM_CFLAGS)
+mateweather_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 mateweather-resources.c: ../data/mateweather-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/mateweather-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name mateweather $<

--- a/mateweather/src/main.c
+++ b/mateweather/src/main.c
@@ -54,4 +54,4 @@ static gboolean mateweather_applet_factory(MatePanelApplet* applet, const gchar*
 	return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY("MateWeatherAppletFactory", PANEL_TYPE_APPLET, "mateweather", mateweather_applet_factory, NULL)
+PANEL_APPLET_FACTORY("MateWeatherAppletFactory", PANEL_TYPE_APPLET, "mateweather", mateweather_applet_factory, NULL)

--- a/mateweather/src/main.c
+++ b/mateweather/src/main.c
@@ -54,4 +54,4 @@ static gboolean mateweather_applet_factory(MatePanelApplet* applet, const gchar*
 	return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY("MateWeatherAppletFactory", PANEL_TYPE_APPLET, "mateweather", mateweather_applet_factory, NULL)
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY("MateWeatherAppletFactory", PANEL_TYPE_APPLET, "mateweather", mateweather_applet_factory, NULL)

--- a/mateweather/src/mateweather-applet.c
+++ b/mateweather/src/mateweather-applet.c
@@ -341,6 +341,10 @@ void mateweather_applet_create (MateWeatherApplet *gw_applet)
 
     mate_panel_applet_set_flags (gw_applet->applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Weather Report"));
+#endif
+
     gtk_window_set_default_icon_name ("weather-storm");
 
     g_signal_connect (gw_applet->applet, "change-orient",

--- a/mateweather/src/mateweather-applet.c
+++ b/mateweather/src/mateweather-applet.c
@@ -341,8 +341,6 @@ void mateweather_applet_create (MateWeatherApplet *gw_applet)
 
     mate_panel_applet_set_flags (gw_applet->applet, MATE_PANEL_APPLET_EXPAND_MINOR);
 
-    g_set_application_name (_("Weather Report"));
-
     gtk_window_set_default_icon_name ("weather-storm");
 
     g_signal_connect (gw_applet->applet, "change-orient",

--- a/multiload/data/Makefile.am
+++ b/multiload/data/Makefile.am
@@ -1,35 +1,52 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-multiload-applet.so
+applet_in_files = org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.MultiLoadAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.multiload.gschema.xml.in
 
-multiload_gschema_in_files = org.mate.panel.applet.multiload.gschema.xml.in
-gsettings_SCHEMAS = $(multiload_gschema_in_files:.xml.in=.xml)
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-multiload-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-multiload-applet
+endif !ENABLE_IN_PROCESS
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 appletdir          = $(datadir)/mate-panel/applets
-applet_in_in_files = org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in.in
-applet_in_files    = $(applet_in_in_files:.desktop.in.in=.desktop.in)
 applet_DATA        = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
             -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+            -e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
 
 CLEANFILES = \
 	$(applet_DATA) \
 	$(applet_in_files) \
+	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 
 EXTRA_DIST = \
-	$(applet_in_in_files) \
-	$(multiload_gschema_in_files) \
+	$(applet_in_files).in \
+	$(service_in_files) \
+	$(gschema_in_files) \
 	multiload-applet-menu.xml \
 	multiload-resources.gresource.xml \
 	properties.ui

--- a/multiload/data/Makefile.am
+++ b/multiload/data/Makefile.am
@@ -1,3 +1,7 @@
+NULL =
+
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-multiload-applet.so
+
 multiload_gschema_in_files = org.mate.panel.applet.multiload.gschema.xml.in
 gsettings_SCHEMAS = $(multiload_gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
@@ -9,32 +13,22 @@ applet_DATA        = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
+            -e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
             -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
             $< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir          = $(datadir)/dbus-1/services
-service_in_files    = org.mate.panel.applet.MultiLoadAppletFactory.service.in
-service_DATA        = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.MultiLoadAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 CLEANFILES = \
 	$(applet_DATA) \
 	$(applet_in_files) \
-	$(service_DATA) \
 	$(gsettings_SCHEMAS) \
 	*.gschema.valid
 
 EXTRA_DIST = \
 	$(applet_in_in_files) \
-	$(service_in_files) \
 	$(multiload_gschema_in_files) \
 	multiload-applet-menu.xml \
 	multiload-resources.gresource.xml \

--- a/multiload/data/org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in.in
+++ b/multiload/data/org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=MultiLoadAppletFactory
-Location=@LIBEXECDIR@/mate-multiload-applet
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=MultiLoad Applet Factory
 Description=Factory for creating the load applet.
 
@@ -10,6 +11,7 @@ Description=A system load indicator
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=utilities-system-monitor
 MateComponentId=OAFIID:MATE_MultiLoadApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=multiload

--- a/multiload/data/org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in.in
+++ b/multiload/data/org.mate.applets.MultiLoadApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=MultiLoadAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=MultiLoad Applet Factory
 Description=Factory for creating the load applet.
 

--- a/multiload/data/org.mate.panel.applet.MultiLoadAppletFactory.service.in
+++ b/multiload/data/org.mate.panel.applet.MultiLoadAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.MultiLoadAppletFactory
+Exec=@APPLET_LOCATION@

--- a/multiload/data/org.mate.panel.applet.MultiLoadAppletFactory.service.in
+++ b/multiload/data/org.mate.panel.applet.MultiLoadAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.MultiLoadAppletFactory
-Exec=@LIBEXECDIR@/mate-multiload-applet

--- a/multiload/src/Makefile.am
+++ b/multiload/src/Makefile.am
@@ -1,8 +1,5 @@
 NULL =
 
-mate_multiload_applet_libdir= $(pkglibdir)
-mate_multiload_applet_lib_LTLIBRARIES=libmate-multiload-applet.la
-
 AM_CPPFLAGS = \
 	-I$(srcdir) \
 	-DMULTILOAD_RESOURCE_PATH=\""/org/mate/mate-applets/multiload/"\" \
@@ -11,7 +8,11 @@ AM_CPPFLAGS = \
 	$(GIO_CFLAGS) \
 	${WARN_CFLAGS}
 
-libmate_multiload_applet_la_SOURCES = \
+BUILT_SOURCES = \
+	multiload-resources.c \
+	multiload-resources.h \
+	$(NULL)
+APPLET_SOURCES = \
 	global.h \
 	linux-proc.h \
 	load-graph.h \
@@ -22,15 +23,28 @@ libmate_multiload_applet_la_SOURCES = \
 	netspeed.c netspeed.h \
 	autoscaler.c \
 	autoscaler.h \
-	multiload-resources.c \
-	multiload-resources.h \
 	$(NULL)
 
-libmate_multiload_applet_la_LIBADD = \
+APPLET_LIBS = \
 	$(MATE_APPLETS4_LIBS) \
 	$(GTOP_APPLETS_LIBS) \
 	$(GIO_LIBS) \
 	-lm
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-multiload-applet.la
+nodist_libmate_multiload_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_multiload_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_multiload_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_multiload_applet_la_LDFLAGS = -module -avoid-version
+libmate_multiload_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mate-multiload-applet
+nodist_mate_multiload_applet_SOURCES = $(BUILT_SOURCES)
+mate_multiload_applet_SOURCES = $(APPLET_SOURCES)
+mate_multiload_applet_CFLAGS = $(AM_CFLAGS)
+mate_multiload_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 multiload-resources.c: $(srcdir)/../data/multiload-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/multiload-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name multiload $<
@@ -39,6 +53,7 @@ multiload-resources.h: $(srcdir)/../data/multiload-resources.gresource.xml $(she
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name multiload $<
 
 CLEANFILES = \
+	$(BUILT_SOURCES) \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/multiload/src/Makefile.am
+++ b/multiload/src/Makefile.am
@@ -1,5 +1,8 @@
 NULL =
 
+mate_multiload_applet_libdir= $(pkglibdir)
+mate_multiload_applet_lib_LTLIBRARIES=libmate-multiload-applet.la
+
 AM_CPPFLAGS = \
 	-I$(srcdir) \
 	-DMULTILOAD_RESOURCE_PATH=\""/org/mate/mate-applets/multiload/"\" \
@@ -8,11 +11,7 @@ AM_CPPFLAGS = \
 	$(GIO_CFLAGS) \
 	${WARN_CFLAGS}
 
-libexec_PROGRAMS = mate-multiload-applet
-
-BUILT_SOURCES = multiload-resources.c multiload-resources.h
-nodist_mate_multiload_applet_SOURCES = $(BUILT_SOURCES)
-mate_multiload_applet_SOURCES = \
+libmate_multiload_applet_la_SOURCES = \
 	global.h \
 	linux-proc.h \
 	load-graph.h \
@@ -22,9 +21,12 @@ mate_multiload_applet_SOURCES = \
 	properties.c \
 	netspeed.c netspeed.h \
 	autoscaler.c \
-	autoscaler.h
+	autoscaler.h \
+	multiload-resources.c \
+	multiload-resources.h \
+	$(NULL)
 
-mate_multiload_applet_LDADD = \
+libmate_multiload_applet_la_LIBADD = \
 	$(MATE_APPLETS4_LIBS) \
 	$(GTOP_APPLETS_LIBS) \
 	$(GIO_LIBS) \
@@ -37,7 +39,6 @@ multiload-resources.h: $(srcdir)/../data/multiload-resources.gresource.xml $(she
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name multiload $<
 
 CLEANFILES = \
-	$(BUILT_SOURCES) \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/multiload/src/main.c
+++ b/multiload/src/main.c
@@ -495,6 +495,10 @@ multiload_applet_new(MatePanelApplet *applet, const gchar *iid, gpointer data)
     ma->prop_dialog = NULL;
         ma->last_clicked = 0;
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("System Monitor"));
+#endif
+
     gtk_window_set_default_icon_name ("utilities-system-monitor");
 
     ma->settings = mate_panel_applet_settings_new (applet, "org.mate.panel.applet.multiload");
@@ -573,8 +577,8 @@ multiload_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("MultiLoadAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "multiload",
-                                       multiload_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("MultiLoadAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "multiload",
+                      multiload_factory,
+                      NULL)

--- a/multiload/src/main.c
+++ b/multiload/src/main.c
@@ -495,8 +495,6 @@ multiload_applet_new(MatePanelApplet *applet, const gchar *iid, gpointer data)
     ma->prop_dialog = NULL;
         ma->last_clicked = 0;
 
-    g_set_application_name (_("System Monitor"));
-
     gtk_window_set_default_icon_name ("utilities-system-monitor");
 
     ma->settings = mate_panel_applet_settings_new (applet, "org.mate.panel.applet.multiload");
@@ -575,7 +573,7 @@ multiload_factory (MatePanelApplet *applet,
     return retval;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("MultiLoadAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("MultiLoadAppletFactory",
                                        PANEL_TYPE_APPLET,
                                        "multiload",
                                        multiload_factory,

--- a/netspeed/data/Makefile.am
+++ b/netspeed/data/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-APPLET_LOCATION = $(libexecdir)/mate-netspeed-applet
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-netspeed-applet.so
 
 appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in
@@ -8,20 +8,11 @@ applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-ap
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
-
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.NetspeedAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.NetspeedAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
-		$< > $@
 
 netspeed_gschema_in_files = org.mate.panel.applet.netspeed.gschema.xml.in
 gsettings_SCHEMAS = $(netspeed_gschema_in_files:.xml.in=.xml)
@@ -29,7 +20,6 @@ gsettings_SCHEMAS = $(netspeed_gschema_in_files:.xml.in=.xml)
 
 EXTRA_DIST = \
 	$(applet_in_files).in	\
-	$(service_in_files) \
 	$(netspeed_gschema_in_files) \
 	netspeed-details.ui \
 	netspeed-menu.xml \
@@ -39,7 +29,6 @@ EXTRA_DIST = \
 
 CLEANFILES = \
 	$(gsettings_SCHEMAS) \
-	$(service_DATA) \
 	$(applet_in_files) \
 	$(applet_DATA)
 

--- a/netspeed/data/Makefile.am
+++ b/netspeed/data/Makefile.am
@@ -1,26 +1,44 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-netspeed-applet.so
+applet_in_files = org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.NetspeedAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.netspeed.gschema.xml.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-netspeed-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/mate-netspeed-applet
+endif !ENABLE_IN_PROCESS
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-netspeed_gschema_in_files = org.mate.panel.applet.netspeed.gschema.xml.in
-gsettings_SCHEMAS = $(netspeed_gschema_in_files:.xml.in=.xml)
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 EXTRA_DIST = \
 	$(applet_in_files).in	\
-	$(netspeed_gschema_in_files) \
+	$(service_in_files) \
+	$(gschema_in_files) \
 	netspeed-details.ui \
 	netspeed-menu.xml \
 	netspeed-preferences.ui \
@@ -29,6 +47,7 @@ EXTRA_DIST = \
 
 CLEANFILES = \
 	$(gsettings_SCHEMAS) \
+	$(service_DATA) \
 	$(applet_in_files) \
 	$(applet_DATA)
 

--- a/netspeed/data/org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in.in
+++ b/netspeed/data/org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=NetspeedAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Netspeed Applet Factory
 Description=Netspeed Applet
 

--- a/netspeed/data/org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in.in
+++ b/netspeed/data/org.mate.applets.NetspeedApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=NetspeedAppletFactory
-Location=@LOCATION@
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Netspeed Applet Factory
 Description=Netspeed Applet
 
@@ -10,6 +11,7 @@ Description=Netspeed Applet
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-netspeed-applet
 MateComponentId=OAFIID:MATE_NetspeedApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-netspeed
 X-MATE-Bugzilla-Component=netspeed

--- a/netspeed/data/org.mate.panel.applet.NetspeedAppletFactory.service.in
+++ b/netspeed/data/org.mate.panel.applet.NetspeedAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.NetspeedAppletFactory
-Exec=@LOCATION@

--- a/netspeed/data/org.mate.panel.applet.NetspeedAppletFactory.service.in
+++ b/netspeed/data/org.mate.panel.applet.NetspeedAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.NetspeedAppletFactory
+Exec=@APPLET_LOCATION@

--- a/netspeed/src/Makefile.am
+++ b/netspeed/src/Makefile.am
@@ -1,8 +1,5 @@
 NULL =
 
-mate_netspeed_applet_libdir= $(pkglibdir)
-mate_netspeed_applet_lib_LTLIBRARIES=libmate-netspeed-applet.la
-
 AM_CPPFLAGS =			\
 	-I$(top_srcdir)		\
 	-I$(includedir)		\
@@ -16,34 +13,53 @@ if HAVE_NL
 AM_CPPFLAGS += $(NL_CFLAGS)
 endif
 
-libmate_netspeed_applet_la_SOURCES =	\
+BUILT_SOURCES =			\
+	netspeed-resources.c	\
+	netspeed-resources.h	\
+	$(NULL)
+APPLET_SOURCES =		\
 	backend.h		\
 	backend.c		\
 	netspeed.c		\
 	netspeed.h		\
 	netspeed-preferences.c	\
 	netspeed-preferences.h	\
-	netspeed-resources.c   \
-	netspeed-resources.h   \
 	$(NULL)
 
 if HAVE_NL
-libmate_netspeed_applet_la_SOURCES +=	\
+APPLET_SOURCES +=		\
 	nl80211.h		\
 	ieee80211.h		\
 	$(NULL)
 endif
 
-libmate_netspeed_applet_la_LIBADD = $(GIO_LIBS) $(GTOP_APPLETS_LIBS) \
-       $(MATE_APPLETS4_LIBS) \
-       $(INTLLIBS) -lm
+APPLET_LIBS = \
+	$(GIO_LIBS) \
+	$(GTOP_APPLETS_LIBS) \
+	$(MATE_APPLETS4_LIBS) \
+	$(INTLLIBS) -lm
 
 if HAVE_IW
-libmate_netspeed_applet_la_LIBADD += $(IW_LIBS)
+APPLET_LIBS += $(IW_LIBS)
 endif
 if HAVE_NL
-libmate_netspeed_applet_la_LIBADD += $(NL_LIBS)
+APPLET_LIBS += $(NL_LIBS)
 endif
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-netspeed-applet.la
+nodist_libmate_netspeed_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_netspeed_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_netspeed_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_netspeed_applet_la_LDFLAGS = -module -avoid-version
+libmate_netspeed_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = mate-netspeed-applet
+nodist_mate_netspeed_applet_SOURCES = $(BUILT_SOURCES)
+mate_netspeed_applet_SOURCES = $(APPLET_SOURCES)
+mate_netspeed_applet_CFLAGS = $(AM_CFLAGS)
+mate_netspeed_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 netspeed-resources.c: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name netspeed $<
@@ -52,6 +68,7 @@ netspeed-resources.h: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name netspeed $<
 
 CLEANFILES =			\
+	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/netspeed/src/Makefile.am
+++ b/netspeed/src/Makefile.am
@@ -1,5 +1,8 @@
 NULL =
 
+mate_netspeed_applet_libdir= $(pkglibdir)
+mate_netspeed_applet_lib_LTLIBRARIES=libmate-netspeed-applet.la
+
 AM_CPPFLAGS =			\
 	-I$(top_srcdir)		\
 	-I$(includedir)		\
@@ -13,35 +16,33 @@ if HAVE_NL
 AM_CPPFLAGS += $(NL_CFLAGS)
 endif
 
-libexec_PROGRAMS = mate-netspeed-applet
-
-BUILT_SOURCES = netspeed-resources.c netspeed-resources.h
-nodist_mate_netspeed_applet_SOURCES = $(BUILT_SOURCES)
-mate_netspeed_applet_SOURCES =	\
+libmate_netspeed_applet_la_SOURCES =	\
 	backend.h		\
 	backend.c		\
 	netspeed.c		\
 	netspeed.h		\
 	netspeed-preferences.c	\
 	netspeed-preferences.h	\
+	netspeed-resources.c   \
+	netspeed-resources.h   \
 	$(NULL)
 
 if HAVE_NL
-mate_netspeed_applet_SOURCES +=	\
+libmate_netspeed_applet_la_SOURCES +=	\
 	nl80211.h		\
 	ieee80211.h		\
 	$(NULL)
 endif
 
-mate_netspeed_applet_LDADD = $(GIO_LIBS) $(GTOP_APPLETS_LIBS) \
+libmate_netspeed_applet_la_LIBADD = $(GIO_LIBS) $(GTOP_APPLETS_LIBS) \
        $(MATE_APPLETS4_LIBS) \
        $(INTLLIBS) -lm
 
 if HAVE_IW
-mate_netspeed_applet_LDADD += $(IW_LIBS)
+libmate_netspeed_applet_la_LIBADD += $(IW_LIBS)
 endif
 if HAVE_NL
-mate_netspeed_applet_LDADD += $(NL_LIBS)
+libmate_netspeed_applet_la_LIBADD += $(NL_LIBS)
 endif
 
 netspeed-resources.c: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/netspeed-resources.gresource.xml)
@@ -51,7 +52,6 @@ netspeed-resources.h: $(srcdir)/../data/netspeed-resources.gresource.xml $(shell
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name netspeed $<
 
 CLEANFILES =			\
-	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -1574,7 +1574,6 @@ netspeed_applet_factory (MatePanelApplet *applet,
         return FALSE;
 
     glibtop_init ();
-    g_set_application_name (_("MATE Netspeed"));
 
     netspeed = NETSPEED_APPLET (applet);
     netspeed->icon_theme = gtk_icon_theme_get_default ();
@@ -1680,62 +1679,61 @@ netspeed_applet_factory (MatePanelApplet *applet,
     netspeed->timeout_id = g_timeout_add (REFRESH_TIME,
                                          (GSourceFunc)timeout_function,
                                          netspeed);
-
-    g_signal_connect (applet, "change-size",
+    g_signal_connect_object (applet, "change-size",
                       G_CALLBACK (applet_change_size_or_orient),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->icon_theme, "changed",
+    g_signal_connect_object (netspeed->icon_theme, "changed",
                       G_CALLBACK (icon_theme_changed_cb),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (applet, "change-orient",
+    g_signal_connect_object (applet, "change-orient",
                       G_CALLBACK (applet_change_size_or_orient),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->in_label, "size-allocate",
+    g_signal_connect_object (netspeed->in_label, "size-allocate",
                       G_CALLBACK (label_size_allocate_cb),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->out_label, "size-allocate",
+    g_signal_connect_object (netspeed->out_label, "size-allocate",
                       G_CALLBACK (label_size_allocate_cb),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->sum_label, "size-allocate",
+    g_signal_connect_object (netspeed->sum_label, "size-allocate",
                       G_CALLBACK (label_size_allocate_cb),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::auto-change-device",
+    g_signal_connect_object (netspeed->settings, "changed::auto-change-device",
                       G_CALLBACK (auto_change_device_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::device",
+    g_signal_connect_object (netspeed->settings, "changed::device",
                       G_CALLBACK (device_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::show-all-addresses",
+    g_signal_connect_object (netspeed->settings, "changed::show-all-addresses",
                       G_CALLBACK (showalladdresses_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::show-sum",
+    g_signal_connect_object (netspeed->settings, "changed::show-sum",
                       G_CALLBACK (showsum_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::show-bits",
+    g_signal_connect_object (netspeed->settings, "changed::show-bits",
                       G_CALLBACK (showbits_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::change-icon",
+    g_signal_connect_object (netspeed->settings, "changed::change-icon",
                       G_CALLBACK (changeicon_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::show-icon",
+    g_signal_connect_object (netspeed->settings, "changed::show-icon",
                       G_CALLBACK (showicon_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
-    g_signal_connect (netspeed->settings, "changed::show-quality-icon",
+    g_signal_connect_object (netspeed->settings, "changed::show-quality-icon",
                       G_CALLBACK (showqualityicon_settings_changed),
-                      netspeed);
+                      netspeed, 0);
 
     action_group = gtk_action_group_new ("Netspeed Applet Actions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
@@ -1761,7 +1759,7 @@ netspeed_applet_factory (MatePanelApplet *applet,
     return TRUE;
 }
 
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY ("NetspeedAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("NetspeedAppletFactory",
                                        NETSPEED_TYPE_APPLET,
                                        "NetspeedApplet",
                                        netspeed_applet_factory,

--- a/netspeed/src/netspeed.c
+++ b/netspeed/src/netspeed.c
@@ -1575,6 +1575,10 @@ netspeed_applet_factory (MatePanelApplet *applet,
 
     glibtop_init ();
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("MATE Netspeed"));
+#endif
+
     netspeed = NETSPEED_APPLET (applet);
     netspeed->icon_theme = gtk_icon_theme_get_default ();
 
@@ -1680,60 +1684,60 @@ netspeed_applet_factory (MatePanelApplet *applet,
                                          (GSourceFunc)timeout_function,
                                          netspeed);
     g_signal_connect_object (applet, "change-size",
-                      G_CALLBACK (applet_change_size_or_orient),
-                      netspeed, 0);
+                             G_CALLBACK (applet_change_size_or_orient),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->icon_theme, "changed",
-                      G_CALLBACK (icon_theme_changed_cb),
-                      netspeed, 0);
+                             G_CALLBACK (icon_theme_changed_cb),
+                             netspeed, 0);
 
     g_signal_connect_object (applet, "change-orient",
-                      G_CALLBACK (applet_change_size_or_orient),
-                      netspeed, 0);
+                             G_CALLBACK (applet_change_size_or_orient),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->in_label, "size-allocate",
-                      G_CALLBACK (label_size_allocate_cb),
-                      netspeed, 0);
+                             G_CALLBACK (label_size_allocate_cb),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->out_label, "size-allocate",
-                      G_CALLBACK (label_size_allocate_cb),
-                      netspeed, 0);
+                             G_CALLBACK (label_size_allocate_cb),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->sum_label, "size-allocate",
-                      G_CALLBACK (label_size_allocate_cb),
-                      netspeed, 0);
+                             G_CALLBACK (label_size_allocate_cb),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::auto-change-device",
-                      G_CALLBACK (auto_change_device_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (auto_change_device_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::device",
-                      G_CALLBACK (device_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (device_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::show-all-addresses",
-                      G_CALLBACK (showalladdresses_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (showalladdresses_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::show-sum",
-                      G_CALLBACK (showsum_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (showsum_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::show-bits",
-                      G_CALLBACK (showbits_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (showbits_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::change-icon",
-                      G_CALLBACK (changeicon_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (changeicon_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::show-icon",
-                      G_CALLBACK (showicon_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (showicon_settings_changed),
+                             netspeed, 0);
 
     g_signal_connect_object (netspeed->settings, "changed::show-quality-icon",
-                      G_CALLBACK (showqualityicon_settings_changed),
-                      netspeed, 0);
+                             G_CALLBACK (showqualityicon_settings_changed),
+                             netspeed, 0);
 
     action_group = gtk_action_group_new ("Netspeed Applet Actions");
     gtk_action_group_set_translation_domain (action_group, GETTEXT_PACKAGE);
@@ -1759,8 +1763,8 @@ netspeed_applet_factory (MatePanelApplet *applet,
     return TRUE;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("NetspeedAppletFactory",
-                                       NETSPEED_TYPE_APPLET,
-                                       "NetspeedApplet",
-                                       netspeed_applet_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("NetspeedAppletFactory",
+                      NETSPEED_TYPE_APPLET,
+                      "NetspeedApplet",
+                      netspeed_applet_factory,
+                      NULL)

--- a/stickynotes/Makefile.am
+++ b/stickynotes/Makefile.am
@@ -1,11 +1,7 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-stickynotes-applet.so
-
 SUBDIRS = pixmaps docs
 
-mate_stickynotes_applet_libdir= $(pkglibdir)
-mate_stickynotes_applet_lib_LTLIBRARIES=libmate-stickynotes-applet.la
 applet_in_files = org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in
 service_in_files = org.mate.panel.applet.StickyNotesAppletFactory.service.in
 schemas_in_files = stickynotes.schemas.in
@@ -22,7 +18,11 @@ AM_CPPFLAGS =					\
 	${WARN_CFLAGS}				\
 	$(NULL)
 
-libmate_stickynotes_applet_la_SOURCES =			\
+BUILT_SOURCES =					\
+	sticky-notes-resources.c		\
+	sticky-notes-resources.h		\
+	$(NULL)
+APPLET_SOURCES =				\
 	util.h					\
 	util.c					\
 	stickynotes.h				\
@@ -33,17 +33,40 @@ libmate_stickynotes_applet_la_SOURCES =			\
 	stickynotes_callbacks.c			\
 	stickynotes_applet.c			\
 	stickynotes_applet_callbacks.c		\
-	sticky-notes-resources.c		\
-	sticky-notes-resources.h		\
 	$(NULL)
 
-libmate_stickynotes_applet_la_LIBADD =			\
+APPLET_LIBS =					\
 	$(STICKYNOTES_LIBS)			\
 	$(MATE_APPLETS4_LIBS)			\
 	$(LIBWNCK_LIBS)				\
 	$(XML2_LIBS)				\
 	-lX11					\
 	$(NULL)
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-stickynotes-applet.so
+pkglib_LTLIBRARIES = libmate-stickynotes-applet.la
+nodist_libmate_stickynotes_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_stickynotes_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_stickynotes_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_stickynotes_applet_la_LDFLAGS = -module -avoid-version
+libmate_stickynotes_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/stickynotes-applet
+libexec_PROGRAMS = stickynotes-applet
+nodist_stickynotes_applet_SOURCES = $(BUILT_SOURCES)
+stickynotes_applet_SOURCES = $(APPLET_SOURCES)
+stickynotes_applet_CFLAGS = $(AM_CFLAGS)
+stickynotes_applet_LDADD = $(APPLET_LIBS)
+
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
 
 stickynotes_gschema_in_files = org.mate.stickynotes.gschema.xml.in
 gsettings_SCHEMAS = $(stickynotes_gschema_in_files:.xml.in=.xml)
@@ -61,6 +84,7 @@ applet_DATA = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet
 $(applet_in_files): $(applet_in_files:=.in) Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
@@ -70,16 +94,19 @@ $(applet_DATA): $(applet_in_files) Makefile
 CLEANFILES =					\
 	$(applet_DATA)				\
 	$(applet_in_files)			\
+	$(service_DATA)				\
 	$(gsettings_SCHEMAS)			\
 	sticky-notes-resources.c		\
 	sticky-notes-resources.h		\
 	*.gschema.valid				\
+	$(BUILT_SOURCES)			\
 	$(NULL)
 
 endif
 
 EXTRA_DIST =					\
 	$(stickynotes_gschema_in_files)		\
+	$(service_in_files)			\
 	$(applet_in_files:=.in)			\
 	sticky-notes-delete.ui                  \
 	sticky-notes-delete-all.ui              \

--- a/stickynotes/Makefile.am
+++ b/stickynotes/Makefile.am
@@ -1,5 +1,11 @@
+NULL =
+
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-stickynotes-applet.so
+
 SUBDIRS = pixmaps docs
 
+mate_stickynotes_applet_libdir= $(pkglibdir)
+mate_stickynotes_applet_lib_LTLIBRARIES=libmate-stickynotes-applet.la
 applet_in_files = org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in
 service_in_files = org.mate.panel.applet.StickyNotesAppletFactory.service.in
 schemas_in_files = stickynotes.schemas.in
@@ -16,9 +22,7 @@ AM_CPPFLAGS =					\
 	${WARN_CFLAGS}				\
 	$(NULL)
 
-libexec_PROGRAMS = stickynotes-applet
-
-stickynotes_applet_SOURCES =			\
+libmate_stickynotes_applet_la_SOURCES =			\
 	util.h					\
 	util.c					\
 	stickynotes.h				\
@@ -33,7 +37,7 @@ stickynotes_applet_SOURCES =			\
 	sticky-notes-resources.h		\
 	$(NULL)
 
-stickynotes_applet_LDADD =			\
+libmate_stickynotes_applet_la_LIBADD =			\
 	$(STICKYNOTES_LIBS)			\
 	$(MATE_APPLETS4_LIBS)			\
 	$(LIBWNCK_LIBS)				\
@@ -56,25 +60,16 @@ applet_DATA = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet
 
 $(applet_in_files): $(applet_in_files:=.in) Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
-            $< > $@
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
+		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir   = $(datadir)/dbus-1/services
-service_DATA = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.StickyNotesAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
-
 CLEANFILES =					\
 	$(applet_DATA)				\
 	$(applet_in_files)			\
-	$(service_DATA)				\
 	$(gsettings_SCHEMAS)			\
 	sticky-notes-resources.c		\
 	sticky-notes-resources.h		\
@@ -85,7 +80,6 @@ endif
 
 EXTRA_DIST =					\
 	$(stickynotes_gschema_in_files)		\
-	$(service_in_files)			\
 	$(applet_in_files:=.in)			\
 	sticky-notes-delete.ui                  \
 	sticky-notes-delete-all.ui              \

--- a/stickynotes/org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in.in
+++ b/stickynotes/org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=StickyNotesAppletFactory
-Location=@LIBEXECDIR@/stickynotes-applet
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Sticky Notes Applet Factory
 Description=Sticky Notes Applet Factory
 
@@ -10,6 +11,7 @@ Description=Create, view, and manage sticky notes on the desktop
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-sticky-notes-applet
 MateComponentId=OAFIID:MATE_StickyNotesApplet
+Platforms=X11;Wayland;
 X-MATE-Bugzilla-Bugzilla=MATE
 X-MATE-Bugzilla-Product=mate-applets
 X-MATE-Bugzilla-Component=stickynotes

--- a/stickynotes/org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in.in
+++ b/stickynotes/org.mate.applets.StickyNotesApplet.mate-panel-applet.desktop.in.in
@@ -1,7 +1,7 @@
 [Applet Factory]
 Id=StickyNotesAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Sticky Notes Applet Factory
 Description=Sticky Notes Applet Factory
 

--- a/stickynotes/org.mate.panel.applet.StickyNotesAppletFactory.service.in
+++ b/stickynotes/org.mate.panel.applet.StickyNotesAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.StickyNotesAppletFactory
+Exec=@APPLET_LOCATION@

--- a/stickynotes/org.mate.panel.applet.StickyNotesAppletFactory.service.in
+++ b/stickynotes/org.mate.panel.applet.StickyNotesAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.StickyNotesAppletFactory
-Exec=@LIBEXECDIR@/stickynotes-applet

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -822,8 +822,8 @@ stickynotes_save_now (void)
     xmlDocSetRootElement (doc, root);
     xmlNewProp (root, XML_CHAR ("version"), XML_CHAR (VERSION));
 #ifdef GDK_WINDOWING_X11
-    GdkDisplay *display = gdk_screen_get_display(gdk_screen_get_default());
-    if (GDK_IS_X11_DISPLAY(display))
+    GdkDisplay *display = gdk_screen_get_display (gdk_screen_get_default());
+    if (GDK_IS_X11_DISPLAY (display))
     {
         WnckScreen *wnck_screen = wnck_screen_get_default ();
         wnck_screen_force_update (wnck_screen);
@@ -955,7 +955,7 @@ stickynotes_load (GdkScreen *screen)
     GList *new_nodes; /* Lists of xmlNodePtr's */
     int x, y, w, h;
 #ifdef GDK_WINDOWING_X11
-    GdkDisplay *display = gdk_screen_get_display(gdk_screen_get_default());
+    GdkDisplay *display = gdk_screen_get_display (gdk_screen_get_default());
 #endif
 
     /* The XML file is $HOME/.config/mate/stickynotes-applet, most probably */

--- a/stickynotes/stickynotes_applet.c
+++ b/stickynotes/stickynotes_applet.c
@@ -84,11 +84,11 @@ stickynotes_applet_factory (MatePanelApplet *mate_panel_applet,
 }
 
 /* Sticky Notes applet factory */
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("StickyNotesAppletFactory",
-                                       PANEL_TYPE_APPLET,
-                                       "stickynotes_applet",
-                                       stickynotes_applet_factory,
-                                       NULL)
+PANEL_APPLET_FACTORY ("StickyNotesAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "stickynotes_applet",
+                      stickynotes_applet_factory,
+                      NULL)
 
 /* colorshift a surface */
 static void
@@ -178,6 +178,9 @@ stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
     size = mate_panel_applet_get_size (mate_panel_applet);
     scale = gtk_widget_get_scale_factor (GTK_WIDGET (mate_panel_applet));
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Sticky Notes"));
+#endif
     gtk_window_set_default_icon_name ("mate-sticky-notes-applet");
 
     stickynotes->icon_normal =

--- a/stickynotes/stickynotes_applet_callbacks.h
+++ b/stickynotes/stickynotes_applet_callbacks.h
@@ -41,7 +41,7 @@ applet_focus_cb (GtkWidget         *widget,
                  StickyNotesApplet *applet);
 
 void
-install_check_click_on_desktop (void);
+install_check_click_on_desktop (GdkScreen *screen);
 void
 applet_change_orient_cb (MatePanelApplet       *mate_panel_applet,
                          MatePanelAppletOrient  orient,

--- a/stickynotes/util.c
+++ b/stickynotes/util.c
@@ -57,6 +57,7 @@ xstuff_atom_get (const char *atom_name)
 int
 xstuff_get_current_workspace (GtkWindow *window)
 {
+#ifdef GDK_WINDOWING_X11
     Window      root_window;
     Atom        type = None;
     gulong      nitems;
@@ -68,8 +69,11 @@ xstuff_get_current_workspace (GtkWindow *window)
     GdkDisplay *gdk_display;
     Display    *xdisplay;
 
-    root_window = GDK_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window)));
     gdk_display = gdk_display_get_default ();
+    if  (!GDK_IS_X11_DISPLAY (gdk_display))
+        return -1;
+
+    root_window = GDK_WINDOW_XID (gtk_widget_get_window (GTK_WIDGET (window)));
     xdisplay = GDK_DISPLAY_XDISPLAY (gdk_display);
 
     gdk_x11_display_error_trap_push (gdk_display);
@@ -93,6 +97,9 @@ xstuff_get_current_workspace (GtkWindow *window)
     XFree (num);
 
     return retval;
+#else
+    return -1;
+#endif
 }
 void
 xstuff_change_workspace (GtkWindow *window,

--- a/timerapplet/data/Makefile.am
+++ b/timerapplet/data/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-APPLET_LOCATION = $(libexecdir)/timer-applet
+APPLET_LOCATION = $(libdir)/mate-applets/libmate-timer-applet.so
 
 appletsdir       = $(datadir)/mate-panel/applets
 applets_in_files = org.mate.applets.TimerApplet.mate-panel-applet.desktop.in
@@ -8,19 +8,11 @@ applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
 		$< > $@
 $(applets_DATA): $(applets_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.TimerAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.TimerAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-		-e "s|\@LOCATION\@|$(APPLET_LOCATION)|" \
-		$< > $@
 
 timer_gschema_in_files = org.mate.panel.applet.timer.gschema.xml.in
 gsettings_SCHEMAS = $(timer_gschema_in_files:.xml.in=.xml)
@@ -28,7 +20,6 @@ gsettings_SCHEMAS = $(timer_gschema_in_files:.xml.in=.xml)
 
 EXTRA_DIST =					\
 	$(applets_in_files).in			\
-	$(service_in_files)			\
 	$(timer_gschema_in_files)		\
 	timerapplet-preferences.ui		\
 	timerapplet-resources.gresource.xml	\
@@ -37,7 +28,6 @@ EXTRA_DIST =					\
 CLEANFILES =			\
 	$(applets_DATA)		\
 	$(applets_in_files)	\
-	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
 	*.gschema.valid		\
 	$(NULL)

--- a/timerapplet/data/Makefile.am
+++ b/timerapplet/data/Makefile.am
@@ -1,26 +1,44 @@
 NULL =
 
-APPLET_LOCATION = $(libdir)/mate-applets/libmate-timer-applet.so
+applets_in_files = org.mate.applets.TimerApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.TimerAppletFactory.service.in
+gschema_in_files = org.mate.panel.applet.timer.gschema.xml.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-timer-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/timer-applet
+endif !ENABLE_IN_PROCESS
 
 appletsdir       = $(datadir)/mate-panel/applets
-applets_in_files = org.mate.applets.TimerApplet.mate-panel-applet.desktop.in
 applets_DATA     = $(applets_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applets_in_files): $(applets_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		$< > $@
+
 $(applets_DATA): $(applets_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
 
-timer_gschema_in_files = org.mate.panel.applet.timer.gschema.xml.in
-gsettings_SCHEMAS = $(timer_gschema_in_files:.xml.in=.xml)
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
+
+gsettings_SCHEMAS = $(gschema_in_files:.xml.in=.xml)
 @GSETTINGS_RULES@
 
 EXTRA_DIST =					\
 	$(applets_in_files).in			\
-	$(timer_gschema_in_files)		\
+	$(service_in_files)			\
+	$(gschema_in_files)			\
 	timerapplet-preferences.ui		\
 	timerapplet-resources.gresource.xml	\
 	$(NULL)
@@ -28,6 +46,7 @@ EXTRA_DIST =					\
 CLEANFILES =			\
 	$(applets_DATA)		\
 	$(applets_in_files)	\
+	$(service_DATA)		\
 	$(gsettings_SCHEMAS)	\
 	*.gschema.valid		\
 	$(NULL)

--- a/timerapplet/data/org.mate.applets.TimerApplet.mate-panel-applet.desktop.in.in
+++ b/timerapplet/data/org.mate.applets.TimerApplet.mate-panel-applet.desktop.in.in
@@ -1,13 +1,13 @@
 [Applet Factory]
 Id=TimerAppletFactory
 Location=@APPLET_LOCATION@
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Name=Timer Factory
 Description=Timer Factory
 
 [TimerApplet]
 Name=Timer
 Description=Start a timer and receive a notification when it is finished
-Platforms=X11;Wayland
+Platforms=X11;Wayland;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-panel-clock

--- a/timerapplet/data/org.mate.applets.TimerApplet.mate-panel-applet.desktop.in.in
+++ b/timerapplet/data/org.mate.applets.TimerApplet.mate-panel-applet.desktop.in.in
@@ -1,11 +1,13 @@
 [Applet Factory]
 Id=TimerAppletFactory
-Location=@LOCATION@
+Location=@APPLET_LOCATION@
+InProcess=true
 Name=Timer Factory
 Description=Timer Factory
 
 [TimerApplet]
 Name=Timer
 Description=Start a timer and receive a notification when it is finished
+Platforms=X11;Wayland
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=mate-panel-clock

--- a/timerapplet/data/org.mate.panel.applet.TimerAppletFactory.service.in
+++ b/timerapplet/data/org.mate.panel.applet.TimerAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.TimerAppletFactory
+Exec=@APPLET_LOCATION@

--- a/timerapplet/data/org.mate.panel.applet.TimerAppletFactory.service.in
+++ b/timerapplet/data/org.mate.panel.applet.TimerAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.TimerAppletFactory
-Exec=@LOCATION@

--- a/timerapplet/src/Makefile.am
+++ b/timerapplet/src/Makefile.am
@@ -1,8 +1,5 @@
 NULL =
 
-mate_timer_applet_libdir= $(pkglibdir)
-mate_timer_applet_lib_LTLIBRARIES=libmate-timer-applet.la
-
 AM_CPPFLAGS =				\
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(LIBNOTIFY_CFLAGS)		\
@@ -10,18 +7,35 @@ AM_CPPFLAGS =				\
 	$(DISABLE_DEPRECATED_CFLAGS)	\
 	$(NULL)
 
-libmate_timer_applet_la_SOURCES = 		\
-	timerapplet.c		\
-    timerapplet-resources.c \
-    timerapplet-resources.h  \
+AM_CFLAGS = $(WARN_CFLAGS)
+
+BUILT_SOURCES =			\
+	timerapplet-resources.c	\
+	timerapplet-resources.h	\
+	$(NULL)
+APPLET_SOURCES = 		\
+	timerapplet.c	\
 	$(NULL)
 
-libmate_timer_applet_la_LIBADD =		\
+APPLET_LIBS =			\
 	$(MATE_APPLETS4_LIBS)	\
 	$(LIBNOTIFY_LIBS)	\
 	$(NULL)
 
-libmate_timer_applet_la_CFLAGS = $(WARN_CFLAGS)
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-timer-applet.la
+nodist_libmate_timer_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_timer_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_timer_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_timer_applet_la_LDFLAGS = -module -avoid-version
+libmate_timer_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = timer-applet
+nodist_timer_applet_SOURCES = $(BUILT_SOURCES)
+timer_applet_SOURCES = $(APPLET_SOURCES)
+timer_applet_CFLAGS = $(AM_CFLAGS)
+timer_applet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 timerapplet-resources.c: $(srcdir)/../data/timerapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
@@ -30,6 +44,7 @@ timerapplet-resources.h: $(srcdir)/../data/timerapplet-resources.gresource.xml $
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
 
 CLEANFILES =			\
+	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/timerapplet/src/Makefile.am
+++ b/timerapplet/src/Makefile.am
@@ -1,5 +1,8 @@
 NULL =
 
+mate_timer_applet_libdir= $(pkglibdir)
+mate_timer_applet_lib_LTLIBRARIES=libmate-timer-applet.la
+
 AM_CPPFLAGS =				\
 	$(MATE_APPLETS4_CFLAGS)		\
 	$(LIBNOTIFY_CFLAGS)		\
@@ -7,20 +10,18 @@ AM_CPPFLAGS =				\
 	$(DISABLE_DEPRECATED_CFLAGS)	\
 	$(NULL)
 
-libexec_PROGRAMS = timer-applet
-
-BUILT_SOURCES = timerapplet-resources.c timerapplet-resources.h
-nodist_timer_applet_SOURCES = $(BUILT_SOURCES)
-timer_applet_SOURCES = 		\
+libmate_timer_applet_la_SOURCES = 		\
 	timerapplet.c		\
+    timerapplet-resources.c \
+    timerapplet-resources.h  \
 	$(NULL)
 
-timer_applet_LDADD =		\
+libmate_timer_applet_la_LIBADD =		\
 	$(MATE_APPLETS4_LIBS)	\
 	$(LIBNOTIFY_LIBS)	\
 	$(NULL)
 
-timer_applet_CFLAGS = $(WARN_CFLAGS)
+libmate_timer_applet_la_CFLAGS = $(WARN_CFLAGS)
 
 timerapplet-resources.c: $(srcdir)/../data/timerapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data --generate-dependencies $(srcdir)/../data/timerapplet-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
@@ -29,7 +30,6 @@ timerapplet-resources.h: $(srcdir)/../data/timerapplet-resources.gresource.xml $
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data --generate --c-name timerapplet $<
 
 CLEANFILES =			\
-	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/timerapplet/src/timerapplet.c
+++ b/timerapplet/src/timerapplet.c
@@ -125,6 +125,9 @@ timer_callback (TimerApplet *applet)
     label = NULL;
     tooltip = NULL;
 
+    if (!GTK_IS_WIDGET (applet->label))
+        return FALSE;
+
     name = g_settings_get_string (applet->settings, NAME_KEY);
     atk_obj = gtk_widget_get_accessible (GTK_WIDGET (applet->applet));
 
@@ -373,7 +376,6 @@ timer_applet_fill (MatePanelApplet* applet_widget)
     TimerApplet *applet;
     AtkObject   *atk_obj;
 
-    g_set_application_name (_("Timer Applet"));
     gtk_window_set_default_icon_name (APPLET_ICON);
 
     if (!notify_is_initted ())
@@ -454,7 +456,7 @@ timer_factory (MatePanelApplet* applet, const char* iid, gpointer data)
 }
 
 /* needed by mate-panel applet library */
-MATE_PANEL_APPLET_OUT_PROCESS_FACTORY("TimerAppletFactory",
+MATE_PANEL_APPLET_IN_PROCESS_FACTORY("TimerAppletFactory",
                                       PANEL_TYPE_APPLET,
                                       "Timer applet",
                                       timer_factory,

--- a/timerapplet/src/timerapplet.c
+++ b/timerapplet/src/timerapplet.c
@@ -376,6 +376,9 @@ timer_applet_fill (MatePanelApplet* applet_widget)
     TimerApplet *applet;
     AtkObject   *atk_obj;
 
+#ifndef ENABLE_IN_PROCESS
+    g_set_application_name (_("Timer Applet"));
+#endif
     gtk_window_set_default_icon_name (APPLET_ICON);
 
     if (!notify_is_initted ())
@@ -456,8 +459,8 @@ timer_factory (MatePanelApplet* applet, const char* iid, gpointer data)
 }
 
 /* needed by mate-panel applet library */
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY("TimerAppletFactory",
-                                      PANEL_TYPE_APPLET,
-                                      "Timer applet",
-                                      timer_factory,
-                                      NULL)
+PANEL_APPLET_FACTORY ("TimerAppletFactory",
+                      PANEL_TYPE_APPLET,
+                      "Timer applet",
+                      timer_factory,
+                      NULL)

--- a/trashapplet/data/Makefile.am
+++ b/trashapplet/data/Makefile.am
@@ -1,32 +1,25 @@
+APPLET_LOCATION = $(libdir)/mate-applets/libtrashapplet.so
+
 appletdir       = $(datadir)/mate-panel/applets
 applet_in_files = org.mate.applets.TrashApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            -e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
-            $< > $@
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
+		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
-servicedir       = $(datadir)/dbus-1/services
-service_in_files = org.mate.panel.applet.TrashAppletFactory.service.in
-service_DATA     = $(service_in_files:.service.in=.service)
-
-org.mate.panel.applet.TrashAppletFactory.service: $(service_in_files)
-	$(AM_V_GEN)sed \
-            -e "s|\@LIBEXECDIR\@|$(libexecdir)|" \
-            $< > $@
 
 EXTRA_DIST = \
 	$(applet_in_files).in	\
-	$(service_in_files) \
 	trashapplet-empty-progress.ui \
 	trashapplet-menu.xml \
 	trashapplet-resources.gresource.xml
 
-CLEANFILES = $(applet_DATA) $(applet_in_files) $(service_DATA)
+CLEANFILES = $(applet_DATA) $(applet_in_files)
 
 -include $(top_srcdir)/git.mk

--- a/trashapplet/data/Makefile.am
+++ b/trashapplet/data/Makefile.am
@@ -1,25 +1,42 @@
-APPLET_LOCATION = $(libdir)/mate-applets/libtrashapplet.so
+applet_in_files = org.mate.applets.TrashApplet.mate-panel-applet.desktop.in
+service_in_files = org.mate.panel.applet.TrashAppletFactory.service.in
+
+if ENABLE_IN_PROCESS
+APPLET_LOCATION = $(pkglibdir)/libmate-trash-applet.so
+else !ENABLE_IN_PROCESS
+APPLET_LOCATION = $(libexecdir)/trashapplet
+endif !ENABLE_IN_PROCESS
 
 appletdir       = $(datadir)/mate-panel/applets
-applet_in_files = org.mate.applets.TrashApplet.mate-panel-applet.desktop.in
 applet_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
 
 $(applet_in_files): $(applet_in_files).in Makefile
 	$(AM_V_GEN)sed \
 		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		-e "s|\@APPLET_IN_PROCESS\@|$(APPLET_IN_PROCESS)|" \
 		-e "s|\@VERSION\@|$(PACKAGE_VERSION)|" \
 		$< > $@
 
 $(applet_DATA): $(applet_in_files) Makefile
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+if !ENABLE_IN_PROCESS
+servicedir = $(datadir)/dbus-1/services
+service_DATA = $(service_in_files:.service.in=.service)
 
-EXTRA_DIST = \
-	$(applet_in_files).in	\
-	trashapplet-empty-progress.ui \
-	trashapplet-menu.xml \
+$(service_DATA): $(service_in_files) Makefile
+	$(AM_V_GEN)sed \
+		-e "s|\@APPLET_LOCATION\@|$(APPLET_LOCATION)|" \
+		$< > $@
+endif !ENABLE_IN_PROCESS
+
+EXTRA_DIST =					\
+	$(applet_in_files).in			\
+	$(service_in_files)			\
+	trashapplet-empty-progress.ui		\
+	trashapplet-menu.xml			\
 	trashapplet-resources.gresource.xml
 
-CLEANFILES = $(applet_DATA) $(applet_in_files)
+CLEANFILES = $(applet_DATA) $(applet_in_files) $(service_DATA)
 
 -include $(top_srcdir)/git.mk

--- a/trashapplet/data/org.mate.applets.TrashApplet.mate-panel-applet.desktop.in.in
+++ b/trashapplet/data/org.mate.applets.TrashApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,6 @@
 [Applet Factory]
 Id=TrashAppletFactory
-InProcess=true
+InProcess=@APPLET_IN_PROCESS@
 Location=@APPLET_LOCATION@
 Name=Trash Applet Factory
 Description=Trash Applet Factory

--- a/trashapplet/data/org.mate.applets.TrashApplet.mate-panel-applet.desktop.in.in
+++ b/trashapplet/data/org.mate.applets.TrashApplet.mate-panel-applet.desktop.in.in
@@ -1,6 +1,7 @@
 [Applet Factory]
 Id=TrashAppletFactory
-Location=@LIBEXECDIR@/trashapplet
+InProcess=true
+Location=@APPLET_LOCATION@
 Name=Trash Applet Factory
 Description=Trash Applet Factory
 

--- a/trashapplet/data/org.mate.panel.applet.TrashAppletFactory.service.in
+++ b/trashapplet/data/org.mate.panel.applet.TrashAppletFactory.service.in
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.mate.panel.applet.TrashAppletFactory
-Exec=@LIBEXECDIR@/trashapplet

--- a/trashapplet/data/org.mate.panel.applet.TrashAppletFactory.service.in
+++ b/trashapplet/data/org.mate.panel.applet.TrashAppletFactory.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.mate.panel.applet.TrashAppletFactory
+Exec=@APPLET_LOCATION@

--- a/trashapplet/src/Makefile.am
+++ b/trashapplet/src/Makefile.am
@@ -4,23 +4,37 @@ AM_CPPFLAGS = -I$(top_srcdir)	\
 	-DGRESOURCE=\""/org/mate/mate-applets/trash/\"" \
 	${WARN_CFLAGS}
 
-trashapplet_libdir= $(pkglibdir)
-trashapplet_lib_LTLIBRARIES=libtrashapplet.la
-
-libtrashapplet_la_SOURCES = \
-	trashapplet.c \
-	trash-empty.h \
-	trash-empty.c \
-	xstuff.c \
-	xstuff.h \
-	trashapplet-resources.c \
-	trashapplet-resources.h \
+BUILT_SOURCES =			\
+	trashapplet-resources.c	\
+	trashapplet-resources.h	\
+	$(NULL)
+APPLET_SOURCES =	\
+	trashapplet.c	\
+	trash-empty.h	\
+	trash-empty.c	\
+	xstuff.c	\
+	xstuff.h	\
 	$(NULL)
 
-libtrashapplet_la_LIBADD = 		\
-	$(MATE_APPLETS4_LIBS) 	\
-	$(GIO_LIBS) \
+APPLET_LIBS = 			\
+	$(MATE_APPLETS4_LIBS)	\
+	$(GIO_LIBS)		\
 	-lX11
+
+if ENABLE_IN_PROCESS
+pkglib_LTLIBRARIES = libmate-trash-applet.la
+nodist_libmate_trash_applet_la_SOURCES = $(BUILT_SOURCES)
+libmate_trash_applet_la_SOURCES = $(APPLET_SOURCES)
+libmate_trash_applet_la_CFLAGS = $(AM_CFLAGS)
+libmate_trash_applet_la_LDFLAGS = -module -avoid-version
+libmate_trash_applet_la_LIBADD = $(APPLET_LIBS)
+else !ENABLE_IN_PROCESS
+libexec_PROGRAMS = trashapplet
+nodist_trashapplet_SOURCES = $(BUILT_SOURCES)
+trashapplet_SOURCES = $(APPLET_SOURCES)
+trashapplet_CFLAGS = $(AM_CFLAGS)
+trashapplet_LDADD = $(APPLET_LIBS)
+endif !ENABLE_IN_PROCESS
 
 trashapplet-resources.c: ../data/trashapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/trashapplet-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name trashapplet $<
@@ -28,7 +42,8 @@ trashapplet-resources.c: ../data/trashapplet-resources.gresource.xml $(shell $(G
 trashapplet-resources.h: ../data/trashapplet-resources.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir)/../data/ --generate-dependencies $(srcdir)/../data/trashapplet-resources.gresource.xml)
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name trashapplet $<
 
-CLEANFILES = \
+CLEANFILES =			\
+	$(BUILT_SOURCES)	\
 	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/trashapplet/src/Makefile.am
+++ b/trashapplet/src/Makefile.am
@@ -4,21 +4,20 @@ AM_CPPFLAGS = -I$(top_srcdir)	\
 	-DGRESOURCE=\""/org/mate/mate-applets/trash/\"" \
 	${WARN_CFLAGS}
 
-libexec_PROGRAMS = trashapplet
+trashapplet_libdir= $(pkglibdir)
+trashapplet_lib_LTLIBRARIES=libtrashapplet.la
 
-BUILT_SOURCES = \
-	trashapplet-resources.c \
-	trashapplet-resources.h
-
-nodist_trashapplet_SOURCES = $(BUILT_SOURCES)
-trashapplet_SOURCES = \
+libtrashapplet_la_SOURCES = \
 	trashapplet.c \
 	trash-empty.h \
 	trash-empty.c \
 	xstuff.c \
-	xstuff.h
+	xstuff.h \
+	trashapplet-resources.c \
+	trashapplet-resources.h \
+	$(NULL)
 
-trashapplet_LDADD = 		\
+libtrashapplet_la_LIBADD = 		\
 	$(MATE_APPLETS4_LIBS) 	\
 	$(GIO_LIBS) \
 	-lX11
@@ -30,6 +29,6 @@ trashapplet-resources.h: ../data/trashapplet-resources.gresource.xml $(shell $(G
 	$(AM_V_GEN)$(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(srcdir)/../data/ --generate --c-name trashapplet $<
 
 CLEANFILES = \
-	$(BUILT_SOURCES)
+	$(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/trashapplet/src/trashapplet.c
+++ b/trashapplet/src/trashapplet.c
@@ -631,6 +631,10 @@ trash_applet_factory (MatePanelApplet *applet,
       AtkObject *atk_obj;
       GtkActionGroup *action_group;
 
+#ifndef ENABLE_IN_PROCESS
+      g_set_application_name (_("Trash Applet"));
+#endif
+
       gtk_window_set_default_icon_name ("user-trash");
 
       /* Set up the menu */
@@ -659,8 +663,8 @@ trash_applet_factory (MatePanelApplet *applet,
   return retval;
 }
 
-MATE_PANEL_APPLET_IN_PROCESS_FACTORY ("TrashAppletFactory",
-				  TRASH_TYPE_APPLET,
-				  "TrashApplet",
-				  trash_applet_factory,
-				  NULL)
+PANEL_APPLET_FACTORY ("TrashAppletFactory",
+		      TRASH_TYPE_APPLET,
+		      "TrashApplet",
+		      trash_applet_factory,
+		      NULL)


### PR DESCRIPTION
Most mate-panel applets work in wayland the same or nearly the same as on x11 after porting to in-process. 

*Accessx not ported, hard dependency on x11 for keyboard handling. The standalone xkb library could offer a future way to fix this

*The battstat applets works same in x11 and wayland, save that again notifications cannot yet be used

*The charpick applet itself will function in both x11 and wayland, but the primary paste preference does not work in wayland-and even resets the gsettings preference to disable it. Fixing this is probably the job of a wayland session manager. No change in x11 behavior

*Cpufreq and drivemount work same in x11 and wayland as they did in x11 before

*Geyes not ported as the applet cannot see the pointer in wayland once it moves outside the panel due to wayland restrictions on one app accessing another's windows. This is considered a security feature in wayland as it makes clickjacking much harder. Also when in-process, geyes improperly computes pointer position as it becomes relative to the mate-panel window not the GtkPlug window used for out of process.

*mateweather, multiload,netspeed, stickynotes all seem to work the same in wayland as in x11 and no behavioral differences were noticed in (ONE user) testing

*The timer applet must be used with the dialog not the notification in wayland, as we don't have a wayland-compatable notification daemon yet and the applet will freeze on a failed notification. No change x11 behavior.

*Trash applet works same in x11 and wayland if a wayland-compatable file manager is installed
