### PR TITLE
timer: fix in-process ATK warning

### DIFF
--- a/timerapplet/src/timerapplet.c
+++ b/timerapplet/src/timerapplet.c
@@ -162,7 +162,7 @@ timer_callback (TimerApplet *applet)
             gtk_widget_set_tooltip_text (GTK_WIDGET (applet->label), name);
             gtk_widget_hide (GTK_WIDGET (applet->pause_image));
             atk_object_set_name (atk_obj, label);
-            atk_object_set_description (atk_obj, tooltip);
+            atk_object_set_description (atk_obj, "");
 
             if (g_settings_get_boolean (applet->settings, SHOW_NOTIFICATION_KEY))
             {


### PR DESCRIPTION
Fix `atk_object_set_description: assertion 'description != NULL' failed` warning when timer runs down. Looks like a race condition is present here. Ideally someone with a working orca install (errors out here) would test this, but the warning indicates that we would not be setting anything when` atk_object_set_description` gets called with an empty description anyway.

Alternately, we could set that description to "finished timer" but Orca should already speak the label text, which shows up in Accerciser