### PR TITLE
Fix stickynotes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,15 +297,8 @@ AC_ARG_ENABLE([stickynotes],
     AS_HELP_STRING([--enable-stickynotes], [Enable stickynotes applet.]),
     enable_stickynotes=$enableval,
     enable_stickynotes=yes)
-if test "x$enable_stickynotes" = "xyes"; then
-    PKG_CHECK_MODULES(STICKYNOTES, gtksourceview-4,
-                      have_gtksourceview=yes, have_gtksourceview=no)
 
-    if test "x$enable_stickynotes" = "xyes" -a "x$have_gtksourceview" = "xno"; then
-        AC_MSG_ERROR([Stickynotes explicitly requested but gtksourceview not found])
-    fi
-fi
-AM_CONDITIONAL(BUILD_STICKYNOTES_APPLET, test "x$have_gtksourceview" = "xyes")
+AM_CONDITIONAL(BUILD_STICKYNOTES_APPLET, test "x$enable_stickynotes" = "xyes")
 
 dnl ***************************************************************************
 dnl *** keyboard accessibility status applet check                          ***

--- a/stickynotes/sticky-notes-note.ui
+++ b/stickynotes/sticky-notes-note.ui
@@ -2,9 +2,8 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
-  <requires lib="gtksourceview" version="4.0"/>
-  <object class="GtkSourceBuffer" id="body_buffer">
-    <property name="max_undo_levels">-1</property>
+  <requires lib="GtkTextView" version="4.0"/>
+  <object class="GtkTextBuffer" id="body_buffer">
   </object>
   <object class="GtkMenu" id="stickynote_menu">
     <child>
@@ -129,7 +128,7 @@
             <property name="hscrollbar_policy">never</property>
             <property name="vscrollbar_policy">never</property>
             <child>
-              <object class="GtkSourceView" id="body_text">
+              <object class="GtkTextView" id="body_text">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="wrap_mode">word</property>

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -139,7 +139,7 @@ stickynote_new_aux (GdkScreen *screen,
     gtk_widget_add_events (note->w_lock, GDK_BUTTON_PRESS_MASK);
 
     note->buffer =
-        GTK_SOURCE_BUFFER (gtk_text_view_get_buffer (GTK_TEXT_VIEW (note->w_body)));
+        GTK_TEXT_BUFFER (gtk_text_view_get_buffer (GTK_TEXT_VIEW (note->w_body)));
 
     note->w_close =
         GTK_WIDGET (gtk_builder_get_object (builder, "close_button"));

--- a/stickynotes/stickynotes.c
+++ b/stickynotes/stickynotes.c
@@ -48,6 +48,11 @@ set_icon_geometry (GdkWindow *window,
                    int        width,
                    int        height)
 {
+    /*This is x11-only, so return in wayland or anything else*/
+    GdkScreen *screen = gdk_screen_get_default();
+    if (!(GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen))))
+        return;
+
     gulong data[4];
     Display *dpy;
 
@@ -731,7 +736,15 @@ stickynote_set_visible (StickyNote *note,
             gtk_window_move (GTK_WINDOW (note->w_window),
                              note->x, note->y);
 
-        /* Put the note on all workspaces if necessary. */
+
+
+        /*On x11, Put the note on all workspaces or move it if necessary.
+         *We can't yet change workspace on wayland
+         */
+        GdkScreen *screen = gdk_screen_get_default();
+        if (!(GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen))))
+            return;
+
         if (g_settings_get_boolean (stickynotes->settings, "sticky"))
             gtk_window_stick (GTK_WINDOW (note->w_window));
 

--- a/stickynotes/stickynotes.h
+++ b/stickynotes/stickynotes.h
@@ -24,8 +24,6 @@
 #include <libwnck/libwnck.h>
 #include <stickynotes_applet.h>
 
-#include <gtksourceview/gtksource.h>
-
 typedef struct
 {
     GtkWidget *w_window;                  /* Sticky Note window */

--- a/stickynotes/stickynotes.h
+++ b/stickynotes/stickynotes.h
@@ -50,7 +50,7 @@ typedef struct
     GtkWidget *w_resize_se;               /* Sticky Note resize button (south east) */
     GtkWidget *w_resize_sw;               /* Sticky Note resize button (south west) */
 
-    GtkSourceBuffer *buffer;              /* Sticky Note text buffer for undo/redo */
+    GtkTextBuffer *buffer;              /* Sticky Note text buffer for undo/redo */
 
     GtkCheckMenuItem *w_lock_toggle_item; /* Lock item in the popup menu */
 

--- a/stickynotes/stickynotes_applet.c
+++ b/stickynotes/stickynotes_applet.c
@@ -219,6 +219,16 @@ stickynotes_applet_init (MatePanelApplet *mate_panel_applet)
 #ifdef GDK_WINDOWING_X11
     if (GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen)))
         screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen)) / scale;
+
+    else
+    {
+        /*No root window or primary monitor in wayland unless compositors add it back*/
+        GdkRectangle geometry = {0};
+        GdkMonitor *monitor;
+        monitor = gdk_display_get_monitor (gdk_screen_get_display (screen), 0);
+        gdk_monitor_get_geometry (monitor, &geometry);
+        screen_height = geometry.height;
+    }
 #endif
 
     stickynotes->max_height = (int) (0.8 * (double) screen_height);

--- a/stickynotes/stickynotes_applet_callbacks.c
+++ b/stickynotes/stickynotes_applet_callbacks.c
@@ -126,6 +126,10 @@ static gboolean get_desktop_window (GdkScreen *screen, Window *window)
     int format_returned;
     int length_returned;
 
+    /*This is x11-only, so return FALSE in wayland or anything else*/
+    if (!(GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen))))
+        return FALSE;
+
     root_window = gdk_screen_get_root_window (screen);
 
     if (gdk_property_get (root_window,
@@ -151,7 +155,15 @@ desktop_window_event_filter (GdkXEvent *xevent,
                              GdkEvent  *event,
                              gpointer   data)
 {
-    gboolean desktop_hide = g_settings_get_boolean (stickynotes->settings,
+    gboolean desktop_hide;
+
+    GdkScreen *screen = gdk_screen_get_default();
+    if (!(GDK_IS_X11_DISPLAY (gdk_screen_get_display (screen))))
+    {
+        desktop_hide = FALSE;
+        return GDK_FILTER_CONTINUE;
+    }
+    desktop_hide = g_settings_get_boolean (stickynotes->settings,
                                                     "desktop-hide");
     if (desktop_hide &&
         (((XEvent*)xevent)->xany.type == PropertyNotify) &&

--- a/stickynotes/util.c
+++ b/stickynotes/util.c
@@ -110,6 +110,9 @@ xstuff_change_workspace (GtkWindow *window,
     Display *gdk_display;
     Screen *screen;
 
+    if  (!GDK_IS_X11_DISPLAY (gdk_display_get_default()))
+        return;
+
     gdk_display = GDK_DISPLAY_XDISPLAY (gdk_display_get_default ());
     xwindow = GDK_WINDOW_XID (GDK_WINDOW (gtk_widget_get_window (GTK_WIDGET (window))));
     screen = GDK_SCREEN_XSCREEN (gtk_widget_get_screen (GTK_WIDGET (window)));


### PR DESCRIPTION
Fix failure of stickynotes to show in both x11 and wayland, and wayland segfaults. Do not use GtkSourceView anymore since the current version is not working with stickynotes, use GtkTextView which works fine even if it has fewer features.

Also ensure that when in Wayland (or any future non-x11 windowing system) we don't call x11 specific functions