### PR TITLE
Allow user selection of decimal places for cpu freq

### DIFF
--- a/cpufreq/data/cpufreq-preferences.ui
+++ b/cpufreq/data/cpufreq-preferences.ui
@@ -229,6 +229,47 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_bottom">6</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="prefs_decimal_places_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin_start">18</property>
+                                <property name="label" translatable="yes">_Decimal places:</property>
+                                <property name="use_underline">True</property>
+                                <property name="mnemonic_widget">prefs_decimal_places</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="prefs_decimal_places">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkRadioButton" id="prefs_show_perc">
                             <property name="label" translatable="yes">Show CPU frequency as _percentage</property>
                             <property name="visible">True</property>
@@ -242,7 +283,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>

--- a/cpufreq/data/org.mate.panel.applet.cpufreq.gschema.xml.in
+++ b/cpufreq/data/org.mate.panel.applet.cpufreq.gschema.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <schemalist gettext-domain="@GETTEXT_PACKAGE@">
-  <schema id="org.mate.panel.applet.cpufreq">
+  <schema id="org.mate.panel.applet.cpufreq" path="/org/mate/panel/applet/cpufreq/">
     <key name="cpu" type="i">
       <default>0</default>
       <summary>CPU to Monitor</summary>
@@ -15,6 +15,13 @@
       <default>1</default>
       <summary>The type of text to display (if the text is enabled).</summary>
       <description>A 0 value means to show CPU frequency, 1 to show frequency and units, and 2 to show percentage instead of frequency.</description>
+    </key>
+    <key name="decimal-places" type="i">
+      <default>2</default>
+      <summary>Decimal places for frequency display</summary>
+      <description>
+        How many decimal digits to display for the CPU frequency.
+      </description>
     </key>
   </schema>
 </schemalist>

--- a/cpufreq/src/cpufreq-monitor.h
+++ b/cpufreq/src/cpufreq-monitor.h
@@ -66,6 +66,8 @@ void         cpufreq_monitor_set_cpu                   (CPUFreqMonitor *monitor,
 const gchar *cpufreq_monitor_get_governor              (CPUFreqMonitor *monitor);
 gint         cpufreq_monitor_get_frequency             (CPUFreqMonitor *monitor);
 gint         cpufreq_monitor_get_percentage            (CPUFreqMonitor *monitor);
+gint         cpufreq_monitor_get_decimal_places        (CPUFreqMonitor *monitor);
+void         cpufreq_monitor_set_decimal_places        (CPUFreqMonitor *monitor, gint decimal_places);
 
 G_END_DECLS
 

--- a/cpufreq/src/cpufreq-popup.c
+++ b/cpufreq/src/cpufreq-popup.c
@@ -273,11 +273,14 @@ frequencies_menu_create_actions (CPUFreqPopup *popup)
         gchar       *label;
         gchar       *unit;
         gint         freq;
+        gint         decimal_places = 2;
 
         text = (const gchar *) available_freqs->data;
         freq = atoi (text);
 
-        freq_text = cpufreq_utils_get_frequency_label (freq);
+        // decimal_places = cpufreq_monitor_get_decimal_places (popup->priv->monitor);
+        // ^^^ if you want the freq selector to also use the same number of decimal places as for display
+        freq_text = cpufreq_utils_get_frequency_label (freq, decimal_places);
         unit = cpufreq_utils_get_frequency_unit (freq);
 
         label = g_strdup_printf ("%s %s", freq_text, unit);

--- a/cpufreq/src/cpufreq-prefs.h
+++ b/cpufreq/src/cpufreq-prefs.h
@@ -57,6 +57,7 @@ CPUFreqPrefs       *cpufreq_prefs_new                (GSettings *settings);
 guint               cpufreq_prefs_get_cpu            (CPUFreqPrefs *prefs);
 CPUFreqShowMode     cpufreq_prefs_get_show_mode      (CPUFreqPrefs *prefs);
 CPUFreqShowTextMode cpufreq_prefs_get_show_text_mode (CPUFreqPrefs *prefs);
+guint               cpufreq_prefs_get_decimal_places (CPUFreqPrefs *prefs);
 
 /* Properties dialog */
 void                cpufreq_preferences_dialog_run   (CPUFreqPrefs *prefs,

--- a/cpufreq/src/cpufreq-utils.c
+++ b/cpufreq/src/cpufreq-utils.c
@@ -215,7 +215,7 @@ cpufreq_utils_selector_is_available (void)
 #endif /* HAVE_POLKIT_MATE */
 
 gchar *
-cpufreq_utils_get_frequency_label (guint freq)
+cpufreq_utils_get_frequency_label (guint freq, gint decimal_places)
 {
     gint divisor;
 
@@ -226,8 +226,12 @@ cpufreq_utils_get_frequency_label (guint freq)
 
     if (((freq % divisor) == 0) || divisor == 1000) /* integer */
         return g_strdup_printf ("%d", freq / divisor);
-    else /* float */
-        return g_strdup_printf ("%3.2f", ((gfloat)freq / divisor));
+    else { /* float */
+        gchar format[16];
+        g_snprintf (format, sizeof (format), "%%3.%df", decimal_places);
+
+        return g_strdup_printf (format, ((gfloat)freq / divisor));
+    }
 }
 
 gchar *

--- a/cpufreq/src/cpufreq-utils.h
+++ b/cpufreq/src/cpufreq-utils.h
@@ -24,6 +24,8 @@
 
 #include <glib.h>
 
+#define MAX_DECIMAL_PLACES 2
+
 G_BEGIN_DECLS
 
 /* Useful global methods */
@@ -31,7 +33,8 @@ guint    cpufreq_utils_get_n_cpus            (void);
 void     cpufreq_utils_display_error         (const gchar *message,
                                               const gchar *secondary);
 gboolean cpufreq_utils_selector_is_available (void);
-gchar   *cpufreq_utils_get_frequency_label   (guint        freq);
+gchar   *cpufreq_utils_get_frequency_label   (guint        freq,
+                                              gint         decimal_places);
 gchar   *cpufreq_utils_get_frequency_unit    (guint        freq);
 gboolean cpufreq_utils_governor_is_automatic (const gchar *governor);
 gboolean cpufreq_file_get_contents           (const gchar *filename,


### PR DESCRIPTION
I didn't need to know my cpu frequency to 2 decimal places, and with 8 of these applets on my panel, the space usage was just too much. So I gave the user the ability to select how many decimal places to show on the cpu frequency. Tooltip still shows the maximum, and the maximum is now configurable (and defaults to 2).