### PR TITLE
drivemount: fix use-after-free crash on icon theme change

### DIFF
--- a/drivemount/src/drive-button.c
+++ b/drivemount/src/drive-button.c
@@ -144,6 +144,15 @@ drive_button_dispose (GObject *object)
 {
     DriveButton *self = DRIVE_BUTTON (object);
 
+    /* The "changed" handler was connected to the process-global default icon
+     * theme (see drive_button_new / drive_button_new_from_mount), which
+     * outlives this button.  If we don't disconnect it, the theme keeps a
+     * dangling pointer to the freed button and a later "changed" emission
+     * schedules drive_button_update() on freed memory -> use-after-free crash. */
+    g_signal_handlers_disconnect_by_func (gtk_icon_theme_get_default (),
+                                          G_CALLBACK (drive_button_theme_change),
+                                          self);
+
     drive_button_set_volume (self, NULL);
 
     if (self->update_tag)


### PR DESCRIPTION
`DriveButton` connects `drive_button_theme_change` to the process-global default
`GtkIconTheme` `"changed"` signal in `drive_button_new()` and
`drive_button_new_from_mount()`, but `drive_button_dispose()` never disconnected
it. Because the default icon theme outlives the button, after a button is
destroyed (e.g. a volume or mount is removed) a later `"changed"` emission
invokes the callback on freed memory and schedules `drive_button_update()` via
`g_idle_add()`, crashing in the GTK main loop (SIGSEGV inside the
`DRIVE_IS_BUTTON()` type check).

On affected systems this applet has been crashing repeatedly for months, around
USB device plug/unplug.

Disconnect the handler in `drive_button_dispose()`:

```c
g_signal_handlers_disconnect_by_func (gtk_icon_theme_get_default (),
                                      G_CALLBACK (drive_button_theme_change),
                                      self);
```

Verified with AddressSanitizer: a harness that destroys a `DriveButton` and then
emits `"changed"` on the default icon theme reports `heap-use-after-free` in
`drive_button_queue_update` (via `drive_button_theme_change`) without this
change, and runs cleanly with it.

Fixes #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
